### PR TITLE
fix(identity map): conflict when modifiedAt is equal to previous stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Ability to define aliases on stored values. This allow you to retrieve them without knowing their id.
 
+### Fixed
+
+- Fixed potential conflict in update when stamp was equal to previous update
+
 ## 0.4.0
 
 ### Breaking changes

--- a/Sources/CohesionKit/IdentityMap.swift
+++ b/Sources/CohesionKit/IdentityMap.swift
@@ -57,7 +57,7 @@ public class IdentityMap {
         
         let storage = self.storage(aliased: key) as Storage<Model>
         
-        storage.merge(valueStorage.publisher, modifiedAt: Date().stamp)
+        storage.merge(valueStorage.publisher)
         
         aliases[key] = (storage: storage, token: storage.publisher.sink(receiveValue: { _ in }))
     }
@@ -93,30 +93,50 @@ public class IdentityMap {
         alias: String? = nil,
         modifiedAt: Stamp = Date().stamp
     ) -> AnyPublisher<Element, Never> {
-        let id = element[keyPath: relation.idKeyPath]
+        _store(element, using: relation, alias: alias, modifiedAt: modifiedAt).map(\.object).eraseToAnyPublisher()
+    }
         
+    func _store<Element, ID: Hashable>(
+        _ element: Element,
+        using relation: Relation<Element, ID>,
+        alias: String? = nil,
+        modifiedAt: Stamp = Date().stamp
+    ) -> AnyPublisher<StampedObject<Element>, Never> {
+        let id = element[keyPath: relation.idKeyPath]
         let storage = self[Element.self, id: id, init: Storage<Element>(id: id, identityMap: self)]
         
-        storage.merge(
-            recursiveStore(element, using: relation, modifiedAt: modifiedAt),
-            modifiedAt: modifiedAt
-        )
+        storage.merge(recursiveStore(element, using: relation, modifiedAt: modifiedAt))
+        
         
         register(alias: alias, storage: storage)
 
         return storage.publisher
     }
     
-    /// Add or update multiple elements at once into the storage
-    /// - Returns: a Publisher emitting a new value when any element from `sequence` is updated in the identity map
     public func store<S: Sequence, ID: Hashable>(
         _ sequence: S,
         using relation: Relation<S.Element, ID>,
         modifiedAt: Stamp = Date().stamp
     ) -> AnyPublisher<[S.Element], Never> {
+        _store(sequence, using: relation, modifiedAt: modifiedAt).map(\.object).eraseToAnyPublisher()
+    }
+    
+    /// Add or update multiple elements at once into the storage
+    /// - Returns: a Publisher emitting a new value when any element from `sequence` is updated in the identity map
+    func _store<S: Sequence, ID: Hashable>(
+        _ sequence: S,
+        using relation: Relation<S.Element, ID>,
+        modifiedAt: Stamp = Date().stamp
+    ) -> AnyPublisher<StampedObject<[S.Element]>, Never> {
         sequence
-            .map { object in store(object, using: relation, modifiedAt: modifiedAt) }
+            .map { object in _store(object, using: relation, modifiedAt: modifiedAt) }
             .combineLatest()
+            .map { collection in
+                collection.reduce((object: [], modifiedAt: 0)) { result, element in
+                    (object: result.object + [element.object], modifiedAt: max(result.modifiedAt, element.modifiedAt))
+                }
+            }
+            .eraseToAnyPublisher()
     }
     
     /// Update element in the storage only if it's already in it. Otherwise discard the changes.
@@ -152,11 +172,12 @@ public class IdentityMap {
         let storage = self[Element.self, id: id, init: Storage<Element>(id: id, identityMap: self)]
         
         return storage.publisher
+            .map(\.object).eraseToAnyPublisher()
     }
     
     /// Return a publisher emitting event when receiving update on `alias`
     public func publisher<Element>(for element: Element.Type, aliased alias: String) -> AnyPublisher<Element, Never> {
-        storage(aliased: alias).publisher
+        storage(aliased: alias).publisher.map(\.object).eraseToAnyPublisher()
     }
 
     /// Return element with matching `id` if an object with such `id` was previously inserted
@@ -173,23 +194,33 @@ public class IdentityMap {
         _ element: Element,
         using relation: Relation<Element, ID>,
         modifiedAt: Stamp = Date().stamp
-    ) -> AnyPublisher<Element, Never> {
+    ) -> AnyPublisher<StampedObject<Element>, Never> {
         guard !relation.allChildren.isEmpty else {
-            return Just(element).eraseToAnyPublisher()
+            return Just((object: element, modifiedAt: modifiedAt)).eraseToAnyPublisher()
         }
-        
+
         return relation
             .allChildren
             .map { identityPath in
                 identityPath
                     .store(element, self, modifiedAt)
-                    .map { (identityPath.keyPath, $0) }
+                    .map { (key: identityPath.keyPath, value: $0) }
             }
             .combineLatest()
             // aggregate updates if multiple children are updated in short time
             .debounce(for: 0.1, scheduler: DispatchQueue.global(qos: .utility))
-            .map { relation.reduce(Updated(root: element, updates: Dictionary(uniqueKeysWithValues: $0))) }
-            .prepend(element)
+            .map {
+                $0.reduce(into: (updates: [:], modifiedAt: 0)) { result, element in
+                    result.updates[element.key] = element.value.0
+                    result.modifiedAt = max(result.modifiedAt, element.value.1)
+                }
+            }
+            .map {
+                (
+                    object: relation.reduce(Updated(root: element, updates: $0.updates)),
+                    modifiedAt: $0.modifiedAt
+                )
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/Sources/CohesionKit/RelationKeyPath.swift
+++ b/Sources/CohesionKit/RelationKeyPath.swift
@@ -2,10 +2,10 @@ import Combine
 
 /// A `KeyPath` with its associated `Relation`
 public struct RelationKeyPath<Root> {
-    let keyPath: AnyKeyPath
+    let keyPath: PartialKeyPath<Root>
     /// method called when storing the element into IdentityMap
     /// we define it here in order to access the keypath exact type in `init`
-    let store: (Root, IdentityMap, Stamp) -> AnyPublisher<Any, Never>
+    let store: (Root, IdentityMap, Stamp) -> AnyPublisher<(Any, Stamp), Never>
     
     /// Build a relation from root with an `Identifiable` child
     public init<T: Identifiable>(_ keyPath: KeyPath<Root, T>) {
@@ -23,8 +23,8 @@ public struct RelationKeyPath<Root> {
         self.keyPath = keyPath
         store = { root, identityMap, stamp in
             identityMap
-                .store(root[keyPath: keyPath], using: relation, modifiedAt: stamp)
-                .map { $0 as Any }
+                ._store(root[keyPath: keyPath], using: relation, modifiedAt: stamp)
+                .map { $0 as (Any, Stamp) }
                 .eraseToAnyPublisher()
         }
     }
@@ -34,8 +34,8 @@ public struct RelationKeyPath<Root> {
         self.keyPath = keyPath
         store = { root, identityMap, modificationId in
             identityMap
-                .store(root[keyPath: keyPath], using: relation, modifiedAt: modificationId)
-                .map { $0 as Any }
+                ._store(root[keyPath: keyPath], using: relation, modifiedAt: modificationId)
+                .map { $0 as (Any, Stamp) }
                 .eraseToAnyPublisher()
         }
     }

--- a/Sources/CohesionKit/Storage.swift
+++ b/Sources/CohesionKit/Storage.swift
@@ -13,10 +13,11 @@ typealias StampedObject<D> = (object: D, modifiedAt: Stamp)
 
 class Storage<T> {
     private let subject: CurrentValueSubject<StampedObject<T>?, Never>
-    private(set) var publisher: AnyPublisher<T, Never>!
+    private(set) var publisher: AnyPublisher<StampedObject<T>, Never>!
     private var upstreamCancellable: AnyCancellable?
     
     var value: T? { subject.value?.object }
+    var modifiedAt: Stamp { subject.value?.modifiedAt ?? 0 }
 
     /// init an empty storage
     convenience init(id: Any, identityMap: IdentityMap) {
@@ -28,7 +29,7 @@ class Storage<T> {
     init(remove: @escaping () -> Void) {
         self.subject = CurrentValueSubject(nil)
         self.publisher = subject
-            .compactMap { $0?.object }
+            .compactMap { $0 }
             .handleEvents(receiveCancel: { [weak self] in
                 // avoid some exclusive memory access by first releasing upstream
                 // which might itself remove content from identity map
@@ -42,18 +43,18 @@ class Storage<T> {
     /// Send new input to storage and notify any subscribers when value is updated
     /// - Returns: true if storage was updated. Storage is updated only if `stamp` is sup. to storage stamp
     @discardableResult
-    func send(_ input: T, modifiedAt: Stamp) -> Bool {
-        guard subject.value.map({ modifiedAt >= $0.modifiedAt }) ?? true else {
+    func send(_ input: StampedObject<T>) -> Bool {
+        guard modifiedAt < input.modifiedAt else {
             return false
         }
 
-        subject.send((object: input, modifiedAt: modifiedAt))
+        subject.send(input)
         return true
     }
 
     /// Merge value from `upstream` into the storage
-    func merge(_ upstream: AnyPublisher<T, Never>, modifiedAt: Stamp) {
+    func merge(_ upstream: AnyPublisher<StampedObject<T>, Never>) {
         upstreamCancellable = upstream
-            .sink(receiveValue: { [weak self] in self?.send($0, modifiedAt: modifiedAt) })
+            .sink(receiveValue: { [weak self] in self?.send($0) })
     }
 }

--- a/Tests/CohesionKitTests/StorageTests.swift
+++ b/Tests/CohesionKitTests/StorageTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+import Combine
+@testable import CohesionKit
+
+class StorageTests: XCTestCase {
+    func test_send_modifiedAtEqualPreviousModification_valueIsNotChanged() {
+        let storage = Storage<String> {
+            
+        }
+        let stamp = Date().stamp
+        
+        storage.send((object: "hello", modifiedAt: stamp))
+        storage.send((object: "hello world", modifiedAt: stamp))
+        
+        XCTAssertEqual(storage.value, "hello")
+    }
+}


### PR DESCRIPTION
Fixed a bug where update could be wrong when modifiedAt is equal to previous stamp. Now we compute the stamp for relationship objects everytime it's updated to have the latest one.