### PR TITLE
tech(api): public api

### DIFF
--- a/Sources/CohesionKit/Combine/EntityObserver+Publisher.swift
+++ b/Sources/CohesionKit/Combine/EntityObserver+Publisher.swift
@@ -1,16 +1,5 @@
+#if canImport(Combine)
 import Combine
-
-/// A protocol abstracting EntityObserver. It exist only for making extension over `Array<EntityObserver<T>>`.
-/// Don't use it!
-public protocol _EntityObserver {
-    associatedtype T
-    
-    var value: T { get }
-    
-    func observe(onChange: @escaping (T) -> Void) -> Subscription
-}
-
-extension EntityObserver: _EntityObserver { }
 
 extension _EntityObserver {
     /// A `Publisher` emitting the observer current value and subscribing to any subsequents new values
@@ -40,3 +29,17 @@ extension Array where Element: _EntityObserver {
             .eraseToAnyPublisher()
     }
 }
+
+#endif
+
+/// A protocol abstracting EntityObserver. It exist only for making extension over `Array<EntityObserver<T>>`.
+/// Don't use it!
+public protocol _EntityObserver {
+    associatedtype T
+    
+    var value: T { get }
+    
+    func observe(onChange: @escaping (T) -> Void) -> Subscription
+}
+
+extension EntityObserver: _EntityObserver { }

--- a/Sources/CohesionKit/Combine/EntityObserver+Publisher.swift
+++ b/Sources/CohesionKit/Combine/EntityObserver+Publisher.swift
@@ -1,0 +1,42 @@
+import Combine
+
+/// A protocol abstracting EntityObserver. It exist only for making extension over `Array<EntityObserver<T>>`.
+/// Don't use it!
+public protocol _EntityObserver {
+    associatedtype T
+    
+    var value: T { get }
+    
+    func observe(onChange: @escaping (T) -> Void) -> Subscription
+}
+
+extension EntityObserver: _EntityObserver { }
+
+extension _EntityObserver {
+    /// A `Publisher` emitting the observer current value and subscribing to any subsequents new values
+    public var publisher: AnyPublisher<T, Never> {
+        let subject = CurrentValueSubject<T, Never>(value)
+        let subscription = observe(onChange: subject.send)
+        
+        return subject
+            .handleEvents(receiveCancel: { subscription.unsubscribe() })
+            .eraseToAnyPublisher()
+    }
+}
+
+extension Array where Element: _EntityObserver {
+    /// A `Publisher` emitting each observer current value and subscribing to any subsequents new values
+    public var publisher: AnyPublisher<[Element.T], Never> {
+        let subject = CurrentValueSubject<[Element.T], Never>(map(\.value))
+        
+        let subscriptions = indices.map { index in
+            self[index].observe {
+                subject.value[index] = $0
+            }
+        }
+        
+        return subject
+            .handleEvents(receiveCancel: { subscriptions.forEach { $0.unsubscribe() } })
+            .eraseToAnyPublisher()
+    }
+}

--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -5,7 +5,25 @@ public class IdentityMap {
     private(set) var storage: WeakStorage = WeakStorage()
     private lazy var storeVisitor = IdentityMapStoreVisitor(identityMap: self)
     
-    func store<T: Identifiable>(entity: T, modifiedAt: Stamp = Date().stamp) -> EntityNode<T> {
+    public func store<T: Identifiable>(entity: T, modifiedAt: Stamp = Date().stamp) -> EntityObserver<T> {
+        EntityObserver(node: store(entity: entity, modifiedAt: modifiedAt))
+    }
+    
+    public func store<T: Aggregate>(entity: T, modifiedAt: Stamp = Date().stamp) -> EntityObserver<T> {
+        EntityObserver(node: store(entity: entity, modifiedAt: modifiedAt))
+    }
+    
+    public func store<C: Collection>(entities: C, modifiedAt: Stamp = Date().stamp) -> [EntityObserver<C.Element>]
+    where C.Element: Identifiable {
+        entities.map { EntityObserver(node: store(entity: $0, modifiedAt: modifiedAt)) }
+    }
+    
+    public func store<C: Collection>(entities: C, modifiedAt: Stamp = Date().stamp) -> [EntityObserver<C.Element>]
+    where C.Element: Aggregate {
+        entities.map { EntityObserver(node: store(entity: $0, modifiedAt: modifiedAt)) }
+    }
+    
+    func store<T: Identifiable>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
         guard let node = storage[entity] else {
             let node = EntityNode(entity, modifiedAt: modifiedAt)
             
@@ -19,7 +37,7 @@ public class IdentityMap {
         return node
     }
     
-    func store<T: Aggregate>(entity: T, modifiedAt: Stamp = Date().stamp) -> EntityNode<T> {
+    func store<T: Aggregate>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
         let node = storage[entity] ?? EntityNode(entity, modifiedAt: modifiedAt)
         var entity = entity
         
@@ -50,18 +68,6 @@ public class IdentityMap {
         node.applyChildrenChanges = true
 
         return node
-    }
-    
-    // TODO: try to reduce the number of updates this might trigger
-    func store<C: Collection>(entities: C, modifiedAt: Stamp = Date().stamp)
-    -> [EntityNode<C.Element>] where C.Element: Identifiable {
-        entities.map { store(entity: $0, modifiedAt: modifiedAt) }
-    }
-    
-    // TODO: try to reduce the number of updates this might trigger
-    func store<C: Collection>(entities: C, modifiedAt: Stamp = Date().stamp)
-    -> [EntityNode<C.Element>] where C.Element: Aggregate {
-        entities.map { store(entity: $0, modifiedAt: modifiedAt) }
     }
 
 }

--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -23,6 +23,14 @@ public class IdentityMap {
         entities.map { EntityObserver(node: store(entity: $0, modifiedAt: modifiedAt)) }
     }
     
+    public func find<T: Identifiable>(_ type: T.Type, id: T.ID) -> EntityObserver<T>? {
+        if let node = storage[EntityNode<T>.self, id: id] {
+            return EntityObserver(node: node)
+        }
+        
+        return nil
+    }
+    
     func store<T: Identifiable>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
         guard let node = storage[entity] else {
             let node = EntityNode(entity, modifiedAt: modifiedAt)

--- a/Sources/CohesionKit/Ref.swift
+++ b/Sources/CohesionKit/Ref.swift
@@ -4,7 +4,15 @@ public class Subscription {
     public let unsubscribe: () -> Void
     
     init(unsubscribe: @escaping () -> Void) {
-        self.unsubscribe = unsubscribe
+        var unsubscribed = false
+        
+        self.unsubscribe = {
+            if !unsubscribed {
+                unsubscribe()
+            }
+            
+            unsubscribed = true
+        }
     }
     
     deinit {

--- a/Sources/CohesionKit/Ref.swift
+++ b/Sources/CohesionKit/Ref.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 public class Subscription {
     public let unsubscribe: () -> Void
     

--- a/Sources/CohesionKit/Ref.swift
+++ b/Sources/CohesionKit/Ref.swift
@@ -26,7 +26,7 @@ class Ref<T> {
         self.value = value
     }
     
-    func addObserver(_ onChange: @escaping (T) -> Void) -> Subscription {
+    func addObserver(onChange: @escaping (T) -> Void) -> Subscription {
         let uuid = UUID()
         
         observers[uuid] = onChange

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -21,8 +21,8 @@ public struct EntityObserver<T> {
     /// - Parameter onChange: a closure called when value changed
     /// - Returns: a subscription to cancel observation. Observation is automatically cancelled if subscription is deinit.
     /// As long as the subscription is alived the entity is kept in the IdentityMap.
-    func observe(_ onChange: @escaping (T) -> Void) -> Subscription {
-        let subscription = node.ref.addObserver(onChange)
+    public func observe(onChange: @escaping (T) -> Void) -> Subscription {
+        let subscription = node.ref.addObserver(onChange: onChange)
         let retain = Unmanaged.passRetained(node)
         
         return Subscription {

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -9,6 +9,13 @@ protocol AnyEntityNode: AnyObject {
 /// A type registering observers on a given entity
 public struct EntityObserver<T> {
     let node: EntityNode<T>
+    /// the value at the time the observer was created. If you want **realtime** value use `observe to get notified of changes
+    public let value: T
+    
+    init(node: EntityNode<T>) {
+        self.node = node
+        self.value = node.value as! T
+    }
     
     /// Add an observer being notified when entity change
     /// - Parameter onChange: a closure called when value changed

--- a/Tests/CohesionKitTests/Combine/EntityObserverTests+Publisher.swift
+++ b/Tests/CohesionKitTests/Combine/EntityObserverTests+Publisher.swift
@@ -1,0 +1,78 @@
+import Combine
+import XCTest
+@testable import CohesionKit
+
+class EntityObserverPublisherTests: XCTestCase {
+    var cancellables: Set<AnyCancellable> = []
+    
+    override func setUp() {
+        cancellables = []
+    }
+    
+    func test_publisher_valueChange_receiveUpdate() {
+        let node = EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)
+        let expected = SingleNodeFixture(id: 1, primitive: "hello")
+        let observer = EntityObserver(node: node)
+        let expectation = XCTestExpectation()
+        
+        observer.publisher
+            .dropFirst()
+            .sink(receiveValue: {
+                expectation.fulfill()
+                XCTAssertEqual($0, expected)
+            })
+            .store(in: &cancellables)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            node.updateEntity(expected, modifiedAt: 1)
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    func test_publisher_streamIsCancelled_valueChange_receiveNothing() {
+        let node = EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)
+        let observer = EntityObserver(node: node)
+        let expectation = XCTestExpectation()
+        
+        expectation.isInverted = true
+        
+        observer.publisher
+            .dropFirst()
+            .sink(receiveValue: { _ in expectation.fulfill() })
+            .store(in: &cancellables)
+        
+        cancellables.removeAll()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            node.updateEntity(SingleNodeFixture(id: 1, primitive: "hello"), modifiedAt: 1)
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    func test_publisherArray_oneValueChange_receiveArrayUpdate() {
+        let value1 = SingleNodeFixture(id: 1)
+        let value2Modified = SingleNodeFixture(id: 2, primitive: "hello")
+        let node2 = EntityNode(SingleNodeFixture(id: 2), modifiedAt: 0)
+        let observers = [
+            EntityObserver(node: EntityNode(value1, modifiedAt: 0)),
+            EntityObserver(node: node2)
+        ]
+        let expectation = XCTestExpectation()
+        
+        observers.publisher
+            .dropFirst()
+            .sink(receiveValue: {
+                expectation.fulfill()
+                XCTAssertEqual($0, [value1, value2Modified])
+            })
+            .store(in: &cancellables)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            node2.updateEntity(value2Modified, modifiedAt: 1)
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -49,4 +49,33 @@ class IdentityMapTests: XCTestCase {
         XCTAssertEqual((node.value as! RootFixture).listNodes, nestedArray)
     }
 
+    func test_find_entityStored_noObserverAdded_returnNil() {
+        let identityMap = IdentityMap()
+        let entity = SingleNodeFixture(id: 1)
+        
+        _ = identityMap.store(entity: entity)
+        
+        XCTAssertNil(identityMap.find(SingleNodeFixture.self, id: 1))
+    }
+    
+    func test_find_entityStored_observedAdded_subscriptionDeinit_returnNil() {
+        let identityMap = IdentityMap()
+        let entity = SingleNodeFixture(id: 1)
+        
+        // don't keep a direct ref to EntityObserver to check memory release management
+        _ = identityMap.store(entity: entity).observe { _ in }
+            
+        XCTAssertNil(identityMap.find(SingleNodeFixture.self, id: 1))
+    }
+    
+    func test_find_entityStored_observerAdded_returnEntity() {
+        let identityMap = IdentityMap()
+        let entity = SingleNodeFixture(id: 1)
+        
+        // don't keep a direct ref to EntityObserver to check memory release management
+        withExtendedLifetime(identityMap.store(entity: entity).observe { _ in }) {
+            XCTAssertEqual(identityMap.find(SingleNodeFixture.self, id: 1)?.value, entity)
+        }
+    }
+    
 }

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -23,29 +23,30 @@ class IdentityMapTests: XCTestCase {
         let identityMap = IdentityMap()
         var nestedOptional = OptionalNodeFixture(id: 1)
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: nestedOptional, listNodes: [])
-        var node = identityMap.store(entity: root)
-
+        var node: EntityNode<RootFixture> = identityMap.store(entity: root, modifiedAt: Date().stamp)
+        
         root.optional = nil
-        node = identityMap.store(entity: root)
-
+        node = identityMap.store(entity: root, modifiedAt: Date().stamp)
+        
         nestedOptional.properties = ["bla": "blob"]
         _ = identityMap.store(entity: nestedOptional)
-
+        
         XCTAssertNil((node.value as! RootFixture).optional)
-      }
-
-      func test_storeAggregate_nestedArrayHasEntityRemoved_removedEntityChange_aggregateArrayNotChanged() {
+    }
+    
+    func test_storeAggregate_nestedArrayHasEntityRemoved_removedEntityChange_aggregateArrayNotChanged() {
         let identityMap = IdentityMap()
         var nestedArray: [ListNodeFixture] = [ListNodeFixture(id: 1), ListNodeFixture(id: 2)]
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: OptionalNodeFixture(id: 1), listNodes: nestedArray)
-        var node = identityMap.store(entity: root)
-
+        var node: EntityNode<RootFixture> = identityMap.store(entity: root, modifiedAt: Date().stamp)
+        
         nestedArray.removeLast()
         root.listNodes = nestedArray
-        node = identityMap.store(entity: root)
-
+        node = identityMap.store(entity: root, modifiedAt: Date().stamp)
+        
         _ = identityMap.store(entity: ListNodeFixture(id: 2, key: "changed"))
-
+        
         XCTAssertEqual((node.value as! RootFixture).listNodes, nestedArray)
-      }
+    }
+
 }


### PR DESCRIPTION
Bring public api on `IdentityMap`:

- Return non Combine dependent objects `EntityObserver`
- Add a simple `publisher` extension allowing to make the API Combine compatible
- Make Combine API optional for Linux platforms