### PR TITLE
fix(identity): Fixed finding alias collection

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -52,11 +52,14 @@ public class IdentityMap {
         return nil
     }
     
+    /// Observe the entity registered under `named` alias
     public func find<T: Identifiable>(named: AliasKey<T>) -> AliasObserver<T> {
         AliasObserver(alias: refAliases[named])
     }
     
-    public func find<C: Collection>(named: AliasKey<C>) -> AliasObserver<C> {
+    /// Observe collection registered under `named` alias
+    /// - Returns: an observer returning the alias value. Note that the value will be an Array
+    public func find<C: Collection>(named: AliasKey<C>) -> AliasObserver<[C.Element]> {
         AliasObserver(alias: refAliases[named])
     }
     

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -1,3 +1,4 @@
+/// Keep a strong reference on each aliased node
 typealias AliasStorage = [AnyHashable: AnyRef]
 
 extension AliasStorage {

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -78,7 +78,7 @@ class IdentityMapTests: XCTestCase {
         }
     }
     
-    func test_find_entityStoreWithAlias_subscriptionCancelled_returnValue() {
+    func test_findNamed_entityStored_subscriptionCancelled_returnValue() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
         
@@ -87,7 +87,7 @@ class IdentityMapTests: XCTestCase {
         XCTAssertEqual(identityMap.find(named: .test).value, entity)
     }
     
-    func test_find_entityStoreWithAlias_thenRemoved_returnNil() {
+    func test_findNamed_entityStored_thenRemoved_returnNil() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
         
@@ -96,8 +96,20 @@ class IdentityMapTests: XCTestCase {
         
         XCTAssertNil(identityMap.find(named: .test).value)
     }
+    
+    func test_findNamed_aliasIsACollection_returnEntities() {
+        let identityMap = IdentityMap()
+        
+        _ = identityMap.store(entities: [SingleNodeFixture(id: 1)], named: .listOfNodes)
+        
+        XCTAssertNotNil(identityMap.find(named: .listOfNodes).value)
+    }
 }
 
 private extension AliasKey where T == SingleNodeFixture {
     static let test = AliasKey(named: "test")
+}
+
+private extension AliasKey where T == [SingleNodeFixture] {
+    static let listOfNodes = AliasKey(named: "listOfNodes")
 }


### PR DESCRIPTION
Fixed a bug where `find(named:)` was not working when alias is a collection. The returned type is now enforced to be an Array no matter the Collection entry type.