### PR TITLE
tech(thread): Use DispatchQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ It is designed with latest Swift technologies:
 
 ## Features
 
-- [x] Work with Swift `struct`
-- [x] Store and retrieve `Identifiable` objects
-- [x] Store and retrieve relational objects
-- [x] Store and retrieve objects using aliases
-- [x] Combine asynchronous API
-- [x] In-memory storage
-- [x] Only keep objects you're using (weak memory)
+- [x] Thread safe
+- [x] Lighweight (< 600 lines of code)
 - [x] Simple API
+- [x] Work with plain Swift `struct`
+- [x] Work with `Identifiable` objects
+- [x] Support for Combine
+- [x] Use [aliases](#aliases) to reference named objects
+- [x] Use [(time)stamps](#stale-data) to mark you data
+- [x] In-memory storage
+- [x] Release objects you're not actively using (weak memory)
+
 
 ## Installation
 

--- a/Sources/CohesionKit/Observer/EntityObserver.swift
+++ b/Sources/CohesionKit/Observer/EntityObserver.swift
@@ -1,15 +1,23 @@
+import Foundation
+
 /// A type registering observers on a given entity from identity storage
 public struct EntityObserver<T>: Observer {
     let node: EntityNode<T>
+    let queue: DispatchQueue
     public let value: T
     
-    init(node: EntityNode<T>) {
+    init(node: EntityNode<T>, queue: DispatchQueue) {
+        self.queue = queue
         self.node = node
         self.value = node.value as! T
     }
     
     public func observe(onChange: @escaping (T) -> Void) -> Subscription {
-        let subscription = node.ref.addObserver(onChange: onChange)
+        let subscription = node.ref.addObserver { newValue in
+            queue.async {
+                onChange(newValue)
+            }
+        }
         let retain = Unmanaged.passRetained(node)
         
         return Subscription {

--- a/Tests/CohesionKitTests/Combine/EntityObserverTests+Publisher.swift
+++ b/Tests/CohesionKitTests/Combine/EntityObserverTests+Publisher.swift
@@ -12,7 +12,7 @@ class EntityObserverPublisherTests: XCTestCase {
     func test_publisher_valueChange_receiveUpdate() {
         let node = EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)
         let expected = SingleNodeFixture(id: 1, primitive: "hello")
-        let observer = EntityObserver(node: node)
+        let observer = EntityObserver(node: node, queue: .main)
         let expectation = XCTestExpectation()
         
         observer.asPublisher
@@ -32,7 +32,7 @@ class EntityObserverPublisherTests: XCTestCase {
     
     func test_publisher_streamIsCancelled_valueChange_receiveNothing() {
         let node = EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)
-        let observer = EntityObserver(node: node)
+        let observer = EntityObserver(node: node, queue: .main)
         let expectation = XCTestExpectation()
         
         expectation.isInverted = true

--- a/Tests/CohesionKitTests/Observer/AliasObserverTests.swift
+++ b/Tests/CohesionKitTests/Observer/AliasObserverTests.swift
@@ -2,32 +2,37 @@ import XCTest
 @testable import CohesionKit
 
 class AliasObserverTests: XCTestCase {
-    func test_observe_refChanged_returnRefValue() {
+    func test_observe_refValueChanged_returnRefValue() {
         let ref = Ref(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
-        let observer = AliasObserver(alias: ref)
+        let observer = AliasObserver(alias: ref, queue: .main)
         let newValue = SingleNodeFixture(id: 2)
         var lastReceivedValue: SingleNodeFixture?
+        let expectation = XCTestExpectation()
         
         let subscription = observer.observe {
             lastReceivedValue = $0
+            expectation.fulfill()
         }
         
         withExtendedLifetime(subscription) {
             ref.value = EntityNode(newValue, modifiedAt: 0)
         }
         
+        wait(for: [expectation], timeout: 1)
         XCTAssertEqual(lastReceivedValue, newValue)
     }
     
-    func test_observe_refChanged_subscribeToRefUpdates() throws {
+    func test_observe_refValueChanged_subscribeToValueUpdates() throws {
         let ref = Ref(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
-        let observer = AliasObserver(alias: ref)
+        let observer = AliasObserver(alias: ref, queue: .main)
         let newNode = EntityNode(SingleNodeFixture(id: 2), modifiedAt: 0)
         let newValue = SingleNodeFixture(id: 3)
         var lastReceivedValue: SingleNodeFixture?
+        let expectation = XCTestExpectation()
         
         let subscription = observer.observe {
             lastReceivedValue = $0
+            expectation.fulfill()
         }
         
         try withExtendedLifetime(subscription) {
@@ -35,6 +40,7 @@ class AliasObserverTests: XCTestCase {
             try newNode.updateEntity(newValue, modifiedAt: 1)
         }
         
+        wait(for: [expectation], timeout: 1)
         XCTAssertEqual(lastReceivedValue, newValue)
     }
     
@@ -42,7 +48,7 @@ class AliasObserverTests: XCTestCase {
         let initialValue = SingleNodeFixture(id: 1)
         let node = EntityNode(initialValue, modifiedAt: 0)
         let ref = Ref(value: Optional.some(node))
-        let observer = AliasObserver(alias: ref)
+        let observer = AliasObserver(alias: ref, queue: .main)
         let newValue = SingleNodeFixture(id: 3)
         var lastReceivedValue: SingleNodeFixture?
         


### PR DESCRIPTION
Use a `DispatchQueue` to make calls to `IdentityMap` thread safe.

This is a temporary implementation until we move to actor.