### PR TITLE
[identityMap]: fix first insertion log error

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -137,6 +137,7 @@ public class IdentityMap {
             let node = EntityNode(entity, modifiedAt: modifiedAt)
             
             storage[entity] = node
+            logger?.didStore(T.self, id: entity.id)
             
             return node
         }

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -14,23 +14,26 @@ class EntityNode<T>: AnyEntityNode {
     
     /// An observable entity reference
     let ref: Ref<T>
-    /// last time the ref.value was changed. Any subsequent change must have a bigger `modifiedAt` value to be applied
-    private var modifiedAt: Stamp
+    /// last time the ref.value was changed. Any subsequent change must have a higher value to be applied
+    /// if nil ref has no stamp and any change will be accepted
+    private var modifiedAt: Stamp?
     /// entity children
     private(set) var children: [PartialKeyPath<T>: SubscribedChild] = [:]
     
-    init(ref: Ref<T>, modifiedAt: Stamp) {
+    init(ref: Ref<T>, modifiedAt: Stamp?) {
         self.ref = ref
         self.modifiedAt = modifiedAt
     }
     
-    convenience init(_ entity: T, modifiedAt: Stamp) {
+    convenience init(_ entity: T, modifiedAt: Stamp?) {
         self.init(ref: Ref(value: entity), modifiedAt: modifiedAt)
     }
     
     /// change the entity to a new value only if `modifiedAt` is equal or higher than any registered previous modification
+    /// - Parameter entity the new entity value
+    /// - Parameter modifiedAt the new entity stamp
     func updateEntity(_ entity: T, modifiedAt newModifiedAt: Stamp) throws {
-        guard newModifiedAt > modifiedAt else {
+        if let modifiedAt, newModifiedAt <= modifiedAt  {
             throw StampError.tooOld(current: modifiedAt, received: newModifiedAt)
         }
         

--- a/Sources/CohesionKit/Storage/WeakStorage.swift
+++ b/Sources/CohesionKit/Storage/WeakStorage.swift
@@ -21,4 +21,19 @@ extension WeakStorage {
         get { self[EntityNode<T>.self, id: object.id] }
         set { self[EntityNode<T>.self, id: object.id] = newValue }
     }
+
+    /// - Parameter new: The value to create, store, and return if none is found
+    subscript<T: Identifiable>(_ object: T, new create: @autoclosure () -> EntityNode<T>) -> EntityNode<T> {
+        mutating get {
+            if let value = self[EntityNode<T>.self, id: object.id] {
+                return value
+            }
+
+            let value = create()
+                
+            self[object] = value
+                
+            return value
+        }
+    }
 }

--- a/Tests/CohesionKitTests/Identity/LoggerMock.swift
+++ b/Tests/CohesionKitTests/Identity/LoggerMock.swift
@@ -2,13 +2,14 @@ import CohesionKit
 
 class LoggerMock: Logger {
     var didStoreCalled: ((type: Any.Type, id: Any)) -> () = { _ in }
+    var didFailedCalled: ((type: Any.Type, id: Any)) -> () = { _ in }
 
     func didStore<T>(_ type: T.Type, id: T.ID) where T : Identifiable {
         didStoreCalled((type, id))
     }
 
     func didFailedToStore<T>(_ type: T.Type, id: T.ID, error: Error) where T : Identifiable {
-        
+        didFailedCalled((type, id))
     }
 
     func didRegisterAlias<T>(_ alias: CohesionKit.AliasKey<T>) {

--- a/Tests/CohesionKitTests/Identity/LoggerMock.swift
+++ b/Tests/CohesionKitTests/Identity/LoggerMock.swift
@@ -1,0 +1,21 @@
+import CohesionKit
+
+class LoggerMock: Logger {
+    var didStoreCalled: ((type: Any.Type, id: Any)) -> () = { _ in }
+
+    func didStore<T>(_ type: T.Type, id: T.ID) where T : Identifiable {
+        didStoreCalled((type, id))
+    }
+
+    func didFailedToStore<T>(_ type: T.Type, id: T.ID, error: Error) where T : Identifiable {
+        
+    }
+
+    func didRegisterAlias<T>(_ alias: CohesionKit.AliasKey<T>) {
+        
+    }
+
+    func didUnregisterAlias<T>(_ alias: CohesionKit.AliasKey<T>) {
+        
+    }
+}

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -59,9 +59,13 @@ class IdentityMapTests: XCTestCase {
             expectation.fulfill()
         }
 
+        logger.didFailedCalled = { _ in
+            XCTFail()
+        }
+
         _ = identityMap.store(entity: root)
 
-        wait(for: [expectation], timeout: 0)
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func test_find_entityStored_noObserverAdded_returnNil() {

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -49,6 +49,21 @@ class IdentityMapTests: XCTestCase {
         XCTAssertEqual((node.value as! RootFixture).listNodes, nestedArray)
     }
 
+    func test_storeIdentifiable_entityIsInsertedForThe1stTime_loggerIsCalled() {
+        let logger = LoggerMock()
+        let identityMap = IdentityMap(logger: logger)
+        let root = SingleNodeFixture(id: 1)
+        let expectation = XCTestExpectation()
+        
+        logger.didStoreCalled = { _ in
+            expectation.fulfill()
+        }
+
+        _ = identityMap.store(entity: root)
+
+        wait(for: [expectation], timeout: 0)
+    }
+
     func test_find_entityStored_noObserverAdded_returnNil() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)


### PR DESCRIPTION
Fixed a bug when inserting an entity the first time: `Logger` error method was triggered while the entity was actually inserted.