### PR TITLE
feat(identity): Add update method for aliases

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Combine
 
+/// Manages entities lifecycle and synchronisation
 public class IdentityMap {
     public typealias Update<T> = (inout T) -> Void
 
@@ -11,9 +11,8 @@ public class IdentityMap {
     private let identityQueue = DispatchQueue(label: "com.cohesionkit.identitymap", attributes: .concurrent)
     /// dispatch queue to return the results
     private let observeQueue: DispatchQueue
-    private let lock = NSLock()
     private let logger: Logger?
-    
+
     /// Create a new IdentityMap instance optionally with a queue and a logger
     /// - Parameter queue: the queue on which to receive updates. If not defined it default to main
     /// - Parameter logger: a logger to follow/debug identity internal state
@@ -21,7 +20,7 @@ public class IdentityMap {
         self.logger = logger
         self.observeQueue = queue
     }
-    
+
     /// Store an entity in the storage. Entity will be stored only if stamp (`modifiedAt`) is higher than in previous
     /// insertion.
     /// - Parameter entity: the element to store in the identity map
@@ -32,7 +31,7 @@ public class IdentityMap {
     -> EntityObserver<T> {
         identityQueue.sync(flags: .barrier) {
             let node = nodeStore(entity: entity, modifiedAt: modifiedAt)
-            
+
             if let alias = named {
                 refAliases.insert(node, key: alias)
                 logger?.didRegisterAlias(alias)
@@ -41,7 +40,7 @@ public class IdentityMap {
             return EntityObserver(node: node, queue: observeQueue)
         }
     }
-    
+
     /// Store an aggregate in the storage. Each aggregate entities will be stored only if stamp (`modifiedAt`) is higher than in previous
     /// insertion. Finally aggregate will be stored accordingly to each of its entities.
     /// - Parameter entity: the aggregate to store in the identity map
@@ -52,46 +51,144 @@ public class IdentityMap {
     -> EntityObserver<T> {
         identityQueue.sync(flags: .barrier) {
             let node = nodeStore(entity: entity, modifiedAt: modifiedAt)
-            
+
             if let alias = named {
                 refAliases.insert(node, key: alias)
                 logger?.didRegisterAlias(alias)
             }
-            
+
             return EntityObserver(node: node, queue: observeQueue)
         }
     }
-    
+
     /// Store multiple entities at once
     public func store<C: Collection>(entities: C, named: AliasKey<C>? = nil, modifiedAt: Stamp = Date().stamp)
     -> [EntityObserver<C.Element>] where C.Element: Identifiable {
         identityQueue.sync(flags: .barrier) {
             let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
-            
+
             if let alias = named {
                 refAliases.insert(nodes, key: alias)
                 logger?.didRegisterAlias(alias)
             }
-            
+
             return nodes.map { EntityObserver(node: $0, queue: observeQueue) }
         }
     }
-    
+
     /// store multiple aggregates at once
     public func store<C: Collection>(entities: C, named: AliasKey<C>? = nil, modifiedAt: Stamp = Date().stamp)
     -> [EntityObserver<C.Element>] where C.Element: Aggregate {
         identityQueue.sync(flags: .barrier) {
             let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
-            
+
             if let alias = named {
                 refAliases.insert(nodes, key: alias)
                 logger?.didRegisterAlias(alias)
             }
-            
+
             return nodes.map { EntityObserver(node: $0, queue: observeQueue) }
         }
     }
 
+    /// Try to find an entity/aggregate in the storage.
+    /// - Returns: nil if not found, an `EntityObserver`` otherwise
+    /// - Parameter type: the entity type
+    /// - Parameter id: the entity id
+    public func find<T: Identifiable>(_ type: T.Type, id: T.ID) -> EntityObserver<T>? {
+        identityQueue.sync {
+            if let node = storage[EntityNode<T>.self, id: id] {
+                return EntityObserver(node: node, queue: observeQueue)
+            }
+
+            return nil
+        }
+    }
+
+    /// Try to find an entity/aggregate registered under `named` alias
+    /// - Parameter named: the alias to look for
+    public func find<T: Identifiable>(named: AliasKey<T>) -> AliasObserver<T> {
+        identityQueue.sync {
+            AliasObserver(alias: refAliases[named], queue: observeQueue)
+        }
+    }
+
+    /// Try to find a collected registered under `named` alias
+    /// - Returns: an observer returning the alias value. Note that the value will be an Array
+    public func find<C: Collection>(named: AliasKey<C>) -> AliasObserver<[C.Element]> {
+        identityQueue.sync {
+            AliasObserver(alias: refAliases[named], queue: observeQueue)
+        }
+    }
+
+    /// Remove an alias from the storage
+    public func removeAlias<T>(named: AliasKey<T>) {
+        refAliases.remove(for: named)
+        logger?.didUnregisterAlias(named)
+    }
+
+    /// Remove an alias from the storage
+    public func removeAlias<C: Collection>(named: AliasKey<C>) {
+        refAliases.remove(for: named)
+        logger?.didUnregisterAlias(named)
+    }
+
+    func nodeStore<T: Identifiable>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
+        let node = storage[entity, new: EntityNode(entity, modifiedAt: nil)]
+
+        do {
+            try node.updateEntity(entity, modifiedAt: modifiedAt)
+            logger?.didStore(T.self, id: entity.id)
+        }
+        catch {
+            logger?.didFailedToStore(T.self, id: entity.id, error: error)
+        }
+
+        return node
+    }
+
+    func nodeStore<T: Aggregate>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
+        let node = storage[entity, new: EntityNode(entity, modifiedAt: nil)]
+        var entity = entity
+
+        // disable changes while doing the entity update
+        node.applyChildrenChanges = false
+
+        // clear all children to avoid a removed child to be kept as child
+        node.removeAllChildren()
+
+        for keyPathContainer in entity.nestedEntitiesKeyPaths {
+            keyPathContainer.accept(node, entity, modifiedAt, storeVisitor)
+        }
+
+        // modify the entity with (potentially) new/different child stored value than what we have
+        withUnsafeMutablePointer(to: &entity) {
+            let parent = UnsafeMutableRawPointer($0)
+
+            for (_, child) in node.children {
+                child.selfAssignTo(parent)
+            }
+        }
+
+        // TODO: what about if modifiedAt is < but some of the children actually changed?
+        do {
+            try node.updateEntity(entity, modifiedAt: modifiedAt)
+            logger?.didStore(T.self, id: entity.id)
+        }
+        catch {
+            logger?.didFailedToStore(T.self, id: entity.id, error: error)
+        }
+
+        node.applyChildrenChanges = true
+
+        return node
+    }
+
+}
+
+// MARK: Update
+
+extension IdentityMap {
     /// Updates an **already stored** entity using a closure. This is useful if you don't have a full entity for update
     /// but just a few attributes/modifications.
     ///
@@ -125,98 +222,42 @@ public class IdentityMap {
             return EntityObserver(node: nodeStore(entity: entity, modifiedAt: modifiedAt), queue: observeQueue)
         }
     }
-    
-    /// Try to find an entity/aggregate in the storage.
-    /// - Returns: nil if not found, an `EntityObserver`` otherwise
-    /// - Parameter type: the entity type 
-    /// - Parameter id: the entity id
-    public func find<T: Identifiable>(_ type: T.Type, id: T.ID) -> EntityObserver<T>? {
-        identityQueue.sync {
-            if let node = storage[EntityNode<T>.self, id: id] {
-                return EntityObserver(node: node, queue: observeQueue)
-            }
-            
-            return nil
-        }
-    }
-    
-    /// Try to find an entity/aggregate registered under `named` alias
-    /// - Parameter named: the alias to look for
-    public func find<T: Identifiable>(named: AliasKey<T>) -> AliasObserver<T> {
-        identityQueue.sync {
-            AliasObserver(alias: refAliases[named], queue: observeQueue)
-        }
-    }
-    
-    /// Try to find a collected registered under `named` alias
-    /// - Returns: an observer returning the alias value. Note that the value will be an Array
-    public func find<C: Collection>(named: AliasKey<C>) -> AliasObserver<[C.Element]> {
-        identityQueue.sync {
-            AliasObserver(alias: refAliases[named], queue: observeQueue)
-        }
-    }
-    
-    /// Remove an alias from the storage
-    public func removeAlias<T>(named: AliasKey<T>) {
-        refAliases.remove(for: named)
-        logger?.didUnregisterAlias(named)
-    }
-    
-    /// Remove an alias from the storage
-    public func removeAlias<C: Collection>(named: AliasKey<C>) {
-        refAliases.remove(for: named)
-        logger?.didUnregisterAlias(named)
-    }
-    
-    func nodeStore<T: Identifiable>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
-        let node = storage[entity, new: EntityNode(entity, modifiedAt: nil)]
-        
-        do {
-            try node.updateEntity(entity, modifiedAt: modifiedAt)
-            logger?.didStore(T.self, id: entity.id)
-        }
-        catch {
-            logger?.didFailedToStore(T.self, id: entity.id, error: error)
-        }
-        
-        return node
-    }
-    
-    func nodeStore<T: Aggregate>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
-        let node = storage[entity, new: EntityNode(entity, modifiedAt: nil)]
-        var entity = entity
-        
-        // disable changes while doing the entity update
-        node.applyChildrenChanges = false
-        
-        // clear all children to avoid a removed child to be kept as child
-        node.removeAllChildren()
-        
-        for keyPathContainer in entity.nestedEntitiesKeyPaths {
-            keyPathContainer.accept(node, entity, modifiedAt, storeVisitor)
-        }
-        
-        // modify the entity with (potentially) new/different child stored value than what we have
-        withUnsafeMutablePointer(to: &entity) {
-            let parent = UnsafeMutableRawPointer($0)
-            
-            for (_, child) in node.children {
-                child.selfAssignTo(parent)
-            }
-        }
-        
-        // TODO: what about if modifiedAt is < but some of the children actually changed?
-        do {
-            try node.updateEntity(entity, modifiedAt: modifiedAt)
-            logger?.didStore(T.self, id: entity.id)
-        }
-        catch {
-            logger?.didFailedToStore(T.self, id: entity.id, error: error)
-        }
-        
-        node.applyChildrenChanges = true
 
-        return node
+    /// Updates an **already existing** collection alias content
+    public func update<C: Collection>(named: AliasKey<C>, modifiedAt: Stamp = Date().stamp, _ update: Update<[C.Element]>)
+    -> [EntityObserver<C.Element>]? where C.Element: Identifiable {
+        identityQueue.sync(flags: .barrier) {
+            guard let entities = self.refAliases[named].value else {
+                return nil
+            }
+
+            var values = entities.map(\.ref.value)
+            update(&values)
+
+            let nodes = values.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
+
+            refAliases.insert(nodes, key: named)
+
+            return nodes.map { EntityObserver(node: $0, queue: observeQueue) }
+        }
     }
 
+    /// Updates an **already existing** collection alias content
+    public func update<C: Collection>(named: AliasKey<C>, modifiedAt: Stamp = Date().stamp, _ update: Update<[C.Element]>)
+    -> [EntityObserver<C.Element>]? where C.Element: Aggregate {
+        identityQueue.sync(flags: .barrier) {
+            guard let entities = self.refAliases[named].value else {
+                return nil
+            }
+
+            var values = entities.map(\.ref.value)
+            update(&values)
+
+            let nodes = values.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
+
+            refAliases.insert(nodes, key: named)
+
+            return nodes.map { EntityObserver(node: $0, queue: observeQueue) }
+        }
+    }
 }

--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -193,7 +193,7 @@ extension IdentityMap {
     /// but just a few attributes/modifications.
     ///
     /// - Returns: an `EntityObserver` if the entity is found, nil otherwise
-    public func update<T: Identifiable>(_ type: T.Type, id: T.ID, modifiedAt: Stamp = Date().stamp, _ update: Update<T>)
+    public func update<T: Identifiable>(_ type: T.Type, id: T.ID, modifiedAt: Stamp = Date().stamp, update: Update<T>)
     -> EntityObserver<T>? {
         identityQueue.sync(flags: .barrier) {
             guard var entity = storage[EntityNode<T>.self, id: id]?.ref.value else {
@@ -260,7 +260,7 @@ extension IdentityMap {
     }
 
     /// Updates an **already existing** collection alias content
-    public func update<C: Collection>(named: AliasKey<C>, modifiedAt: Stamp = Date().stamp, _ update: Update<[C.Element]>)
+    public func update<C: Collection>(named: AliasKey<C>, modifiedAt: Stamp = Date().stamp, update: Update<[C.Element]>)
     -> [EntityObserver<C.Element>]? where C.Element: Identifiable {
         identityQueue.sync(flags: .barrier) {
             guard let entities = refAliases[named].value else {
@@ -279,7 +279,7 @@ extension IdentityMap {
     }
 
     /// Updates an **already existing** collection alias content
-    public func update<C: Collection>(named: AliasKey<C>, modifiedAt: Stamp = Date().stamp, _ update: Update<[C.Element]>)
+    public func update<C: Collection>(named: AliasKey<C>, modifiedAt: Stamp = Date().stamp, update: Update<[C.Element]>)
     -> [EntityObserver<C.Element>]? where C.Element: Aggregate {
         identityQueue.sync(flags: .barrier) {
             guard let entities = self.refAliases[named].value else {

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -7,41 +7,41 @@ extension AliasStorage {
             if let store = self[AnyHashable(key)] as? Ref<EntityNode<T>?> {
                 return store
             }
-            
+
             let store: Ref<EntityNode<T>?> = Ref(value: nil)
             self[AnyHashable(key)] = store
-            
+
             return store
-            
+
         }
     }
-    
+
     subscript<C: Collection>(key: AliasKey<C>) -> Ref<[EntityNode<C.Element>]?> {
         mutating get {
             if let store = self[AnyHashable(key)] as? Ref<[EntityNode<C.Element>]?> {
                 return store
             }
-            
+
             let store: Ref<[EntityNode<C.Element>]?> = Ref(value: nil)
             self[AnyHashable(key)] = store
-            
+
             return store
-            
+
         }
     }
-    
+
     mutating func insert<T>(_ node: EntityNode<T>, key: AliasKey<T>) {
         self[key].value = node
     }
-    
+
     mutating func insert<C: Collection>(_ nodes: [EntityNode<C.Element>], key: AliasKey<C>) {
         self[key].value = nodes
     }
-    
+
     mutating func remove<T>(for key: AliasKey<T>) {
         (self[AnyHashable(key)] as? Ref<EntityNode<T>?>)?.value = nil
     }
-    
+
     mutating func remove<C: Collection>(for key: AliasKey<C>) {
         (self[AnyHashable(key)] as? Ref<[EntityNode<C.Element>]?>)?.value = nil
     }

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -11,41 +11,41 @@ class IdentityMapTests: XCTestCase {
             listNodes: [ListNodeFixture(id: 1)]
         )
         let identityMap = IdentityMap()
-        
+
         withExtendedLifetime(identityMap.store(entity: entity)) { _ in
             XCTAssertNotNil(identityMap.storage[EntityNode<SingleNodeFixture>.self, id: 1])
             XCTAssertNotNil(identityMap.storage[EntityNode<OptionalNodeFixture>.self, id: 1])
             XCTAssertNotNil(identityMap.storage[EntityNode<ListNodeFixture>.self, id: 1])
         }
     }
-    
+
     func test_nodeStoreAggregate_nestedOptionalReplacedByNil_previousOptionalIdentityChange_aggregateOptionalNotChanged() {
         let identityMap = IdentityMap()
         var nestedOptional = OptionalNodeFixture(id: 1)
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: nestedOptional, listNodes: [])
         var node: EntityNode<RootFixture> = identityMap.nodeStore(entity: root, modifiedAt: Date().stamp)
-        
+
         root.optional = nil
         node = identityMap.nodeStore(entity: root, modifiedAt: Date().stamp)
-        
+
         nestedOptional.properties = ["bla": "blob"]
         _ = identityMap.store(entity: nestedOptional)
-        
+
         XCTAssertNil((node.value as! RootFixture).optional)
     }
-    
+
     func test_nodeStoreAggregate_nestedArrayHasEntityRemoved_removedEntityChange_aggregateArrayNotChanged() {
         let identityMap = IdentityMap()
         var nestedArray: [ListNodeFixture] = [ListNodeFixture(id: 1), ListNodeFixture(id: 2)]
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: OptionalNodeFixture(id: 1), listNodes: nestedArray)
         var node: EntityNode<RootFixture> = identityMap.nodeStore(entity: root, modifiedAt: Date().stamp)
-        
+
         nestedArray.removeLast()
         root.listNodes = nestedArray
         node = identityMap.nodeStore(entity: root, modifiedAt: Date().stamp)
-        
+
         _ = identityMap.store(entity: ListNodeFixture(id: 2, key: "changed"))
-        
+
         XCTAssertEqual((node.value as! RootFixture).listNodes, nestedArray)
     }
 
@@ -54,7 +54,7 @@ class IdentityMapTests: XCTestCase {
         let identityMap = IdentityMap(logger: logger)
         let root = SingleNodeFixture(id: 1)
         let expectation = XCTestExpectation()
-        
+
         logger.didStoreCalled = { _ in
             expectation.fulfill()
         }
@@ -71,60 +71,60 @@ class IdentityMapTests: XCTestCase {
     func test_find_entityStored_noObserverAdded_returnNil() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
-        
+
         _ = identityMap.store(entity: entity)
-        
+
         XCTAssertNil(identityMap.find(SingleNodeFixture.self, id: 1))
     }
-    
+
     func test_find_entityStored_observedAdded_subscriptionDeinit_returnNil() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
-        
+
         // don't keep a direct ref to EntityObserver to check memory release management
         _ = identityMap.store(entity: entity).observe { _ in }
-            
+
         XCTAssertNil(identityMap.find(SingleNodeFixture.self, id: 1))
     }
-    
+
     func test_find_entityStored_observerAdded_returnEntity() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
-        
+
         // don't keep a direct ref to EntityObserver to check memory release management
         withExtendedLifetime(identityMap.store(entity: entity).observe { _ in }) {
             XCTAssertEqual(identityMap.find(SingleNodeFixture.self, id: 1)?.value, entity)
         }
     }
-    
+
     func test_findNamed_entityStored_subscriptionCancelled_returnValue() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
-        
+
         _ = identityMap.store(entity: entity, named: .test)
-        
+
         XCTAssertEqual(identityMap.find(named: .test).value, entity)
     }
-    
+
     func test_findNamed_entityStored_thenRemoved_returnNil() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
-        
+
         _ = identityMap.store(entity: entity, named: .test)
         identityMap.removeAlias(named: .test)
-        
+
         XCTAssertNil(identityMap.find(named: .test).value)
     }
-    
+
     func test_findNamed_aliasIsACollection_returnEntities() {
         let identityMap = IdentityMap()
-        
+
         _ = identityMap.store(entities: [SingleNodeFixture(id: 1)], named: .listOfNodes)
-        
+
         XCTAssertNotNil(identityMap.find(named: .listOfNodes).value)
     }
 
-    func test_update_entityIsAlreadyInserted_itUpdates() {
+    func test_update_entityIsAlreadyInserted_entityIsUpdated() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
 
@@ -134,6 +134,21 @@ class IdentityMapTests: XCTestCase {
             }
 
             XCTAssertEqual(identityMap.find(SingleNodeFixture.self, id: 1)?.value.primitive, "hello")
+        }
+    }
+
+    func test_updateNamed_aliasIsExisting_existingObserversAreNotified() {
+        let identityMap = IdentityMap(queue: .main)
+        let entities = [SingleNodeFixture(id: 1)]
+        let expectation = XCTestExpectation()
+
+        _ = identityMap.find(named: .listOfNodes).observe {
+            expectation.fulfill()
+            XCTAssertEqual($0, entities)
+        }
+
+        _ = identityMap.update(named: .listOfNodes) {
+            $0.append(contentsOf: entities)
         }
     }
 }

--- a/Tests/CohesionKitTests/Storage/AliasStorageTests.swift
+++ b/Tests/CohesionKitTests/Storage/AliasStorageTests.swift
@@ -4,27 +4,36 @@ import XCTest
 class AliasStorageTests: XCTestCase {
     func test_subscriptGet_aliasIsCollection_noValue_returnRef() {
         var storage: AliasStorage = [:]
-        
+
         XCTAssertNotNil(storage[.testCollection])
         XCTAssertNil(storage[.testCollection].value)
     }
-    
+
     func test_subscriptGet_twoAliasWithSameNameButDifferentType_returnBothCollections() {
         var storage: AliasStorage = [:]
-        
+
         storage[.testCollection].value = [EntityNode(1, modifiedAt: 0), EntityNode(2, modifiedAt: 0)]
         storage[.test].value = EntityNode(3, modifiedAt: 0)
-        
+
         XCTAssertEqual(storage.count, 2)
     }
-    
+
     func test_subscriptGet_valueSet_returnValue() {
         var storage: AliasStorage = [:]
         let expectedValue = [EntityNode(1, modifiedAt: 0)]
-        
+
         storage[.testCollection].value = expectedValue
-        
+
         XCTAssertEqual(storage[.testCollection].value, expectedValue)
+    }
+
+    func test_remove_aliasInsertedBefore_itRemovesValue() {
+        var storage: AliasStorage = [:]
+
+        storage.insert(EntityNode(ref: Ref(value: 1), modifiedAt: nil), key: .test)
+        storage.remove(for: .test)
+
+        XCTAssertNil(storage[.test].value)
     }
 }
 


### PR DESCRIPTION
## ⚽️ Description

Add new methods to update aliases using a closure:

- Moved everything inside an extension
- Made parameter `update` named
- Implementation is the same as previous added methods, but for alias
- Also removed `NSLock` which was not used