### PR TITLE
fix(observer): [#30] Observe alias entity changes

### DIFF
--- a/Tests/CohesionKitTests/Observer/AliasObserverTests.swift
+++ b/Tests/CohesionKitTests/Observer/AliasObserverTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import CohesionKit
 
 class AliasObserverTests: XCTestCase {
-    func test_observe_refValueChanged_returnRefValue() {
+    func test_observe_refValueChanged_onChangeIsCalled() {
         let ref = Ref(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
         let observer = AliasObserver(alias: ref, queue: .main)
         let newValue = SingleNodeFixture(id: 2)
@@ -51,13 +51,38 @@ class AliasObserverTests: XCTestCase {
         let observer = AliasObserver(alias: ref, queue: .main)
         let newValue = SingleNodeFixture(id: 3)
         var lastReceivedValue: SingleNodeFixture?
-        
+
         _ = observer.observe {
             lastReceivedValue = $0
         }
-        
+
         try node.updateEntity(newValue, modifiedAt: 1)
-        
+
         XCTAssertNil(lastReceivedValue)
+    }
+
+    func test_observeArray_oneElementChanged_onChangeIsCalled() throws {
+        let expectation = XCTestExpectation()
+        let entities = [
+            EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0),
+            EntityNode(SingleNodeFixture(id: 2), modifiedAt: 0)
+        ]
+        let ref = Ref(value: Optional.some(entities))
+        let observer = AliasObserver(alias: ref, queue: .main)
+        let update = SingleNodeFixture(id: 1, primitive: "Update")
+        var lastObservedValue: [SingleNodeFixture]?
+
+        let subscription = observer.observe {
+            lastObservedValue = $0
+            expectation.fulfill()
+        }
+
+        try withExtendedLifetime(subscription) {
+            // try ref.value?[0].updateEntity(SingleNodeFixture(id: 1, primitive: "Update"), modifiedAt: 1)
+            try entities[0].updateEntity(SingleNodeFixture(id: 1, primitive: "Update"), modifiedAt: 1)
+
+            wait(for: [expectation], timeout: 1)
+            XCTAssertEqual(lastObservedValue?.first, update)
+        }
     }
 }

--- a/Tests/CohesionKitTests/Observer/EntityObserverTests.swift
+++ b/Tests/CohesionKitTests/Observer/EntityObserverTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import CohesionKit
+
+class EntityObserverTests: XCTestCase {
+    func test_entityIsUpdated_onChangeIsCalled() throws {
+        let node = EntityNode(SingleNodeFixture(id: 0), modifiedAt: 0)
+        let observer = EntityObserver(node: node, queue: .main)
+        let newEntity = SingleNodeFixture(id: 0, primitive: "new entity version")
+        let expectation = XCTestExpectation()
+
+        let subscription = observer.observe {
+            expectation.fulfill()
+            XCTAssertEqual($0, newEntity)
+        }
+
+        try withExtendedLifetime(subscription) {
+            try node.updateEntity(newEntity, modifiedAt: 1)
+            wait(for: [expectation], timeout: 0.5)
+        }
+    }
+}


### PR DESCRIPTION
## ⚽️ Description

Entity changes were not observed the first `AliasObserver` time was created

## 🔨 Implementation details

- observe entity changes when `createObserver` is called
- added unit tests to cover this usecase