### PR TITLE
tech(doc): Add "known limitations" and "store vs update" sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ cancellable = nil
 identityMap.find(Book.self, id: "ACK") // return "A Clash of Kings" because cancellable2 still observe this book
 ```
 
-## Known issues
+## Known limitations
 
 ### Custom collections are not supported
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ CohesionKit will then handle synchronisation for the three entities:
 - Author
 - Book
 
-This allow you to retrieve them independently from each other:
+This allows you to retrieve them independently from each other:
 
 ```swift
 let authorBooks = AuthorBooks(
@@ -176,6 +176,10 @@ identityMap.find(Author.self, id: 1) // George R.R MartinI
 identityMap.find(AuthorBooks.self, id: 1 // George R.R MartinI + [A Clash of Kings, A Dance with Dragons]
 ```
 
+> You might think about storing books on `Author` directly (`author.books`). In this case `Author` would need to implement `Aggregate` and declare `books` are nested entity.
+>
+> However I strongly advise you to not nest `Identifiable` objects into other `Identifiable` objects. Read [Handling relationships](https://swiftunwrap.com/article/modeling-done-right/) article if you want to know more about this subject.
+
 ## Advanced topics
 
 ### Aliases
@@ -189,19 +193,19 @@ extension AliasKey where T == User {
   static let currentUser = AliasKey("user")
 }
 
-identityMap.store(currentUser, named: \.currentUser)
+identityMap.store(currentUser, named: .currentUser)
 ```
 
 Then request it somewhere else:
 
 ```swift
-identityMap.find(named: \.currentUser) // return the current user
+identityMap.find(named: .currentUser) // return the current user
 ```
 
 Compared to regular entities aliased objects are long-live objects: they will be kept in the storage even if no one observe them. This allow registered observers to be notified when alias value change:
 
 ```swift
-identityMap.removeAlias(named: \.currentUser) // observers will be notified currentUser is nil.
+identityMap.removeAlias(named: .currentUser) // observers will be notified currentUser is nil.
 
 identityMap.store(newCurrentUser, named: \.currentUser) // observers will be notified that currentUser changed even if currentUser was nil before
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sequenceDiagram
 		CohesionKit -->> YourApp: Publisher<[A,B,C]>
 
 		WebSocket ->> WebSocketListener: book A updated
-		WebSocketListener ->> CohesionKit: store book A
+		WebSocketListener ->> CohesionKit: update book A
 		CohesionKit -->> YourApp: Publisher<[A,B,C]>
 ```
 
@@ -71,7 +71,7 @@ Library comes with an [example project](https://github.com/pjechris/CohesionKit/
 
 ## Getting started
 
-### Store an object
+### Storing an object
 
 First create an instance of `IdentityMap`:
 
@@ -179,6 +179,15 @@ identityMap.find(AuthorBooks.self, id: 1 // George R.R MartinI + [A Clash of Kin
 > You might think about storing books on `Author` directly (`author.books`). In this case `Author` would need to implement `Aggregate` and declare `books` are nested entity.
 >
 > However I strongly advise you to not nest `Identifiable` objects into other `Identifiable` objects. Read [Handling relationships](https://swiftunwrap.com/article/modeling-done-right/) article if you want to know more about this subject.
+
+### Storing vs Updating
+
+For now we only focused on `identityMap.store` but CohesionKit comes with another method to store data: `identityMap.update`.
+
+Sometimes both can be used but they each have a different purpose:
+
+1. `store` is suited for storing full data retrieved from webservices, like `GET /user` for instance
+2. `update` is usually used for partial data. It's also the preferred method when receiving events from websockets for instances.
 
 ## Advanced topics
 
@@ -290,7 +299,7 @@ let naughtyDog = Author(
 identityMap.store(naughtyDog)
 ```
 
-If associated value changes you might need to do a double update inside the lib in order to propagate the modifications:
+If associated value changes you might need to do a double update inside the lib in order to properly propagate the modifications:
 
 ```swift
 
@@ -299,6 +308,8 @@ let lastOfUsPart1 = Game(id: xx, title: "The Last Of Us", supportedPlatforms: [.
 identityMap.store(lastOfUsPart1) // this only notifies objects direct Game reference, not objects using MovieType.game (like our previous `naughtyDog`)
 identityMap.store(MovieType.game(lastOfUsPart1)) // on the other hand this one notifies objects like naughtyDog but not those using a plain Game
 ```
+
+Note that in this context CohesionKit stores the value twice: once as `Game` and once as `MediaType.game` hence the double update.
 
 
 # License


### PR DESCRIPTION
## ⚽️ Description

Fixes some spelling errors in the doc and add two new sections:

- store vs update, to say when `update` is more suited than `store`
- known limitations with the lib

+ some clarification about how `Aggregate` should ideally be used.