### PR TITLE
feat(identity): Change `update` return type to Bool

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -245,7 +245,8 @@ extension IdentityMap {
             update(&value)
             let node = nodeStore(entity: value, modifiedAt: modifiedAt)
 
-//            refAliases.insert(node, key: named)
+            // ref might have changed
+            refAliases.insert(node, key: named)
 
             return EntityObserver(node: node, queue: observeQueue)
         }
@@ -266,6 +267,9 @@ extension IdentityMap {
             var value = entity.ref.value
             update(&value)
             let node = nodeStore(entity: value, modifiedAt: modifiedAt)
+
+            // ref might have changed
+            refAliases.insert(node, key: named)
 
             return EntityObserver(node: node, queue: observeQueue)
         }


### PR DESCRIPTION
## ⚽️ Description

After using the API for a little while I see no reason for identityMap.update to return an Observer: value will be mostly discarded by caller.

## 🔨 Implementation details

- Changed the type to just return a bool saying whether or not the update could be applied to an existing object
- Added `@discardableResult` annotation