### PR TITLE
feat(identity): Add `removeAll` API to empty storage

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -121,18 +121,6 @@ public class IdentityMap {
         }
     }
 
-    /// Remove an alias from the storage
-    public func removeAlias<T>(named: AliasKey<T>) {
-        refAliases.remove(for: named)
-        logger?.didUnregisterAlias(named)
-    }
-
-    /// Remove an alias from the storage
-    public func removeAlias<C: Collection>(named: AliasKey<C>) {
-        refAliases.remove(for: named)
-        logger?.didUnregisterAlias(named)
-    }
-
     func nodeStore<T: Identifiable>(entity: T, modifiedAt: Stamp) -> EntityNode<T> {
         let node = storage[entity, new: EntityNode(entity, modifiedAt: nil)]
 
@@ -319,5 +307,33 @@ extension IdentityMap {
 
             return true
         }
+    }
+}
+
+// MARK: Delete
+
+extension IdentityMap {
+    /// Removes an alias from the storage
+    public func removeAlias<T>(named: AliasKey<T>) {
+        refAliases.remove(for: named)
+        logger?.didUnregisterAlias(named)
+    }
+
+    /// Removes an alias from the storage
+    public func removeAlias<C: Collection>(named: AliasKey<C>) {
+        refAliases.remove(for: named)
+        logger?.didUnregisterAlias(named)
+    }
+
+    /// Removes all alias from identity map
+    public func removeAllAlias() {
+        refAliases.removeAll()
+    }
+
+    /// Removes all alias AND all objects stored weakly. You should not need this method and rather use `removeAlias`. But this can be useful
+    /// if you fear retain cycles
+    public func removeAll() {
+        refAliases.removeAll()
+        storage.removeAll()
     }
 }

--- a/Sources/CohesionKit/Storage/WeakStorage.swift
+++ b/Sources/CohesionKit/Storage/WeakStorage.swift
@@ -5,7 +5,7 @@ struct WeakStorage {
 
     private var storage: Storage = [:]
 
-    func removeAll() {
+    mutating func removeAll() {
         storage.removeAll()
     }
 

--- a/Sources/CohesionKit/Storage/WeakStorage.swift
+++ b/Sources/CohesionKit/Storage/WeakStorage.swift
@@ -2,14 +2,18 @@ import Foundation
 
 struct WeakStorage {
     typealias Storage = [String: AnyWeak]
-    
+
     private var storage: Storage = [:]
-    
+
+    func removeAll() {
+        storage.removeAll()
+    }
+
     subscript<T: AnyObject>(_ type: T.Type, id id: Any) -> T? {
         get { (storage[key(for: type, id: id)] as? Weak<T>)?.value }
         set { storage[key(for: type, id: id)] = Weak(value: newValue) }
     }
-    
+
     private func key<T>(for type: T.Type, id: Any) -> String {
         "\(type)-\(id)"
     }
@@ -30,9 +34,9 @@ extension WeakStorage {
             }
 
             let value = create()
-                
+
             self[object] = value
-                
+
             return value
         }
     }

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -106,6 +106,22 @@ class IdentityMapTests: XCTestCase {
         XCTAssertEqual(identityMap.find(named: .test).value, entity)
     }
 
+    func test_findNamed_allAliasRemoved_returnNilValue() {
+        let identityMap = IdentityMap(queue: .main)
+
+        _ = identityMap.store(entity: SingleNodeFixture(id: 1), named: .test, modifiedAt: 0)
+
+        XCTAssertNotNil(identityMap.find(named: .test).value)
+
+        identityMap.removeAllAlias()
+
+        XCTAssertNil(identityMap.find(named: .test).value)
+    }
+}
+
+// PRAGMA: Update
+
+extension IdentityMapTests {
     func test_findNamed_entityStored_thenRemoved_returnNil() {
         let identityMap = IdentityMap()
         let entity = SingleNodeFixture(id: 1)
@@ -178,7 +194,6 @@ class IdentityMapTests: XCTestCase {
             wait(for: [expectation], timeout: 0.5)
         }
     }
-
 }
 
 private extension AliasKey where T == SingleNodeFixture {


### PR DESCRIPTION
## ⚽️ Description

Add new APIs to empty storage. This can be useful when user logs out for instance.

## 🔨 Implementation details

API will clean aliases from `IdentityMap`. Also added a method to clear the whole storage (included weaked reference objects). This should not be needed but I added it anyway in case of.