### PR TITLE
feat(data): [#29] Support for MutableCollection

### DIFF
--- a/Sources/CohesionKit/KeyPath/PartialIdentifiableKeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/PartialIdentifiableKeyPath.swift
@@ -45,7 +45,7 @@ public struct PartialIdentifiableKeyPath<Root> {
         }
     }
     
-    public init<C: BufferedCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Identifiable, C.Index == Int {
+    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Identifiable, C.Index == Int {
         self.keyPath = keyPath
         self.accept = { parent, root, stamp, visitor in
             visitor.visit(
@@ -55,7 +55,7 @@ public struct PartialIdentifiableKeyPath<Root> {
         }
     }
     
-    public init<C: BufferedCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Aggregate, C.Index == Int {
+    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Aggregate, C.Index == Int {
         self.keyPath = keyPath
         self.accept = { parent, root, stamp, visitor in
             visitor.visit(

--- a/Sources/CohesionKit/KeyPath/UnsafeMutablePointer+KeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/UnsafeMutablePointer+KeyPath.swift
@@ -20,3 +20,25 @@ extension UnsafeMutableRawPointer {
         pointer.pointee.withContiguousMutableStorageIfAvailable { $0[index] = value }
       }
 }
+
+extension UnsafeMutablePointer {
+
+    func assign<Value>(_ value: Value, to keyPath: KeyPath<Pointee, Value>) {
+
+        guard let unsafePointer = UnsafeMutablePointer<Value>(mutating: pointer(to: keyPath)) else {
+            fatalError("cannot update value for KeyPath<\(Pointee.self), \(Value.self)>. Computed properties are not supported.")
+        }
+
+        unsafePointer.pointee = value
+    }
+    
+    func assign<C: MutableCollection>(_ value: C.Element, to keyPath: KeyPath<Pointee, C>, index: C.Index)
+    where C.Index == Int {
+
+        guard let unsafePointer = UnsafeMutablePointer<C>(mutating: pointer(to: keyPath)) else {
+              fatalError("cannot update value for KeyPath<\(Pointee.self), \(C.self)>. Computed properties are not supported.")
+        }
+
+        unsafePointer.pointee.withContiguousMutableStorageIfAvailable { $0[index] = value }
+    }
+}

--- a/Sources/CohesionKit/KeyPath/UnsafeMutablePointer+KeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/UnsafeMutablePointer+KeyPath.swift
@@ -1,26 +1,5 @@
 import Foundation
 
-extension UnsafeMutableRawPointer {
-    
-    func assign<Root, Value>(_ value: Value, to keyPath: KeyPath<Root, Value>) {
-        guard let pointer = UnsafeMutablePointer(mutating: self.assumingMemoryBound(to: Root.self).pointer(to: keyPath)) else {
-              fatalError("cannot update value for KeyPath<\(Root.self), \(Value.self)>. Computed properties are not supported.")
-        }
-
-        pointer.pointee = value
-    }
-    
-    func assign<Root, C>(_ value: C.Element, to keyPath: KeyPath<Root, C>, index: C.Index)
-      where C: MutableCollection, C.Index == Int {
-
-        guard let pointer = UnsafeMutablePointer(mutating: self.assumingMemoryBound(to: Root.self).pointer(to: keyPath)) else {
-              fatalError("cannot update value for KeyPath<\(Root.self), \(C.self)>. Computed properties are not supported.")
-        }
-
-        pointer.pointee.withContiguousMutableStorageIfAvailable { $0[index] = value }
-      }
-}
-
 extension UnsafeMutablePointer {
 
     func assign<Value>(_ value: Value, to keyPath: KeyPath<Pointee, Value>) {

--- a/Sources/CohesionKit/KeyPath/UnsafeMutableRawPointer+KeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/UnsafeMutableRawPointer+KeyPath.swift
@@ -1,8 +1,4 @@
 import Foundation
-import Accelerate
-
-/// A collection providing an access to its buffer
-public typealias BufferedCollection = Collection & AccelerateMutableBuffer
 
 extension UnsafeMutableRawPointer {
     
@@ -17,7 +13,7 @@ extension UnsafeMutableRawPointer {
     }
     
     func assign<Root, C>(_ value: C.Element, to keyPath: KeyPath<Root, C>, index: C.Index)
-      where C: BufferedCollection, C.Index == Int {
+      where C: MutableCollection, C.Index == Int {
 
         guard let offset = MemoryLayout<Root>.offset(of: keyPath) else {
             fatalError("offset for KeyPath<\(Root.self), \(C.self)> is nil")
@@ -26,6 +22,6 @@ extension UnsafeMutableRawPointer {
         advanced(by: offset)
             .assumingMemoryBound(to: C.self)
             .pointee
-            .withUnsafeMutableBufferPointer { $0[index] = value }
+            .withContiguousMutableStorageIfAvailable { $0[index] = value }
       }
 }

--- a/Sources/CohesionKit/KeyPath/UnsafeMutableRawPointer+KeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/UnsafeMutableRawPointer+KeyPath.swift
@@ -3,25 +3,20 @@ import Foundation
 extension UnsafeMutableRawPointer {
     
     func assign<Root, Value>(_ value: Value, to keyPath: KeyPath<Root, Value>) {
-        guard let offset = MemoryLayout<Root>.offset(of: keyPath) else {
-            fatalError("offset for KeyPath<\(Root.self), \(Value.self)> is nil")
+        guard let pointer = UnsafeMutablePointer(mutating: self.assumingMemoryBound(to: Root.self).pointer(to: keyPath)) else {
+              fatalError("cannot update value for KeyPath<\(Root.self), \(Value.self)>. Computed properties are not supported.")
         }
-        
-        advanced(by: offset)
-            .assumingMemoryBound(to: Value.self)
-            .pointee = value
+
+        pointer.pointee = value
     }
     
     func assign<Root, C>(_ value: C.Element, to keyPath: KeyPath<Root, C>, index: C.Index)
       where C: MutableCollection, C.Index == Int {
 
-        guard let offset = MemoryLayout<Root>.offset(of: keyPath) else {
-            fatalError("offset for KeyPath<\(Root.self), \(C.self)> is nil")
+        guard let pointer = UnsafeMutablePointer(mutating: self.assumingMemoryBound(to: Root.self).pointer(to: keyPath)) else {
+              fatalError("cannot update value for KeyPath<\(Root.self), \(C.self)>. Computed properties are not supported.")
         }
 
-        advanced(by: offset)
-            .assumingMemoryBound(to: C.self)
-            .pointee
-            .withContiguousMutableStorageIfAvailable { $0[index] = value }
+        pointer.pointee.withContiguousMutableStorageIfAvailable { $0[index] = value }
       }
 }

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -60,7 +60,7 @@ class EntityNode<T>: AnyEntityNode {
     }
     
     /// observe one of the node child whose type is a collection
-    func observeChild<C: BufferedCollection>(_ childNode: EntityNode<C.Element>, for keyPath: KeyPath<T, C>, index: C.Index)
+    func observeChild<C: MutableCollection>(_ childNode: EntityNode<C.Element>, for keyPath: KeyPath<T, C>, index: C.Index)
     where C.Index == Int {
         observeChild(childNode, identity: keyPath.appending(path: \C[index])) { pointer, newValue in
             pointer.assign(newValue, to: keyPath, index: index)

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -74,7 +74,7 @@ class EntityNode<T>: AnyEntityNode {
     private func observeChild<C, Element>(
         _ childNode: EntityNode<Element>,
         identity keyPath: KeyPath<T, C>,
-        assign: @escaping (UnsafeMutableRawPointer, Element) -> Void
+        update: @escaping (UnsafeMutablePointer<T>, Element) -> Void
     ) {
         if let subscribedChild = children[keyPath]?.node as? EntityNode<Element>, subscribedChild == childNode {
             return
@@ -85,17 +85,18 @@ class EntityNode<T>: AnyEntityNode {
                 return
             }
 
-            withUnsafeMutablePointer(to: &self.ref.value) {
-                let pointer = UnsafeMutableRawPointer($0)
-                
-                assign(pointer, newValue)
+            withUnsafeMutablePointer(to: &self.ref.value) {                
+                update($0, newValue)
             }
         }
         
         children[keyPath] = SubscribedChild(
             subscription: subscription,
             node: childNode,
-            selfAssignTo: { assign($0, childNode.ref.value) }
+            selfAssignTo: {
+                let selfPointer = $0.assumingMemoryBound(to: T.self)
+                update(selfPointer, childNode.ref.value)
+            }
         )
     }
  

--- a/Sources/CohesionKit/Visitor/IdentityMapStoreVisitor.swift
+++ b/Sources/CohesionKit/Visitor/IdentityMapStoreVisitor.swift
@@ -32,7 +32,7 @@ struct IdentityMapStoreVisitor: NestedEntitiesVisitor {
         }
     }
     
-    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Identifiable, C.Index == Int {
         
         for index in entities.indices {
@@ -44,7 +44,7 @@ struct IdentityMapStoreVisitor: NestedEntitiesVisitor {
         }
     }
     
-    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Aggregate, C.Index == Int {
         
         for index in entities.indices {

--- a/Sources/CohesionKit/Visitor/NestedEntitiesVisitor.swift
+++ b/Sources/CohesionKit/Visitor/NestedEntitiesVisitor.swift
@@ -8,9 +8,9 @@ protocol NestedEntitiesVisitor {
     func visit<Root, T: Identifiable>(context: EntityContext<Root, T?>, entity: T?)
     func visit<Root, T: Aggregate>(context: EntityContext<Root, T?>, entity: T?)
     
-    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Identifiable, C.Index == Int
     
-    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Aggregate, C.Index == Int
 }

--- a/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
+++ b/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
@@ -1,14 +1,12 @@
 import XCTest
 @testable import CohesionKit
 
-class UnsafeMutableRawPointerTests: XCTestCase {
+class UnsafeMutablePointerTests: XCTestCase {
     func test_assign_propertyIsImmutable_propertyIsChanged() {
         var hello = Hello()
 
         withUnsafeMutablePointer(to: &hello) {
-            let pointer = UnsafeMutableRawPointer($0)
-            
-            pointer.assign("world", to: \Hello.singleValue)
+            $0.assign("world", to: \Hello.singleValue)
         }
 
         XCTAssertEqual(hello.singleValue, "world")
@@ -17,10 +15,8 @@ class UnsafeMutableRawPointerTests: XCTestCase {
     func test_assign_keyPathIsCollection_propertyIsImmutable_collectionIsChangedAtIndex() {
         var hello = Hello()
 
-        withUnsafeMutablePointer(to: &hello) {
-            let pointer = UnsafeMutableRawPointer($0)
-            
-            pointer.assign(5, to: \Hello.collection, index: 3)
+        withUnsafeMutablePointer(to: &hello) {            
+            $0.assign(5, to: \Hello.collection, index: 3)
         }
         
         XCTAssertEqual(hello.collection, [1, 2, 3, 5])

--- a/Tests/CohesionKitTests/KeyPath/UnsafeMutableRawPointerTests.swift
+++ b/Tests/CohesionKitTests/KeyPath/UnsafeMutableRawPointerTests.swift
@@ -2,19 +2,32 @@ import XCTest
 @testable import CohesionKit
 
 class UnsafeMutableRawPointerTests: XCTestCase {
-    func test_assign_keyPathIsCollection_assignNewValueToIndex() {
+    func test_assign_propertyIsImmutable_propertyIsChanged() {
         var hello = Hello()
 
         withUnsafeMutablePointer(to: &hello) {
             let pointer = UnsafeMutableRawPointer($0)
             
-            pointer.assign(5, to: \Hello.test, index: 3)
+            pointer.assign("world", to: \Hello.singleValue)
+        }
+
+        XCTAssertEqual(hello.singleValue, "world")
+    }
+
+    func test_assign_keyPathIsCollection_propertyIsImmutable_collectionIsChangedAtIndex() {
+        var hello = Hello()
+
+        withUnsafeMutablePointer(to: &hello) {
+            let pointer = UnsafeMutableRawPointer($0)
+            
+            pointer.assign(5, to: \Hello.collection, index: 3)
         }
         
-        XCTAssertEqual(hello.test, [1, 2, 3, 5])
+        XCTAssertEqual(hello.collection, [1, 2, 3, 5])
     }
 }
 
 private struct Hello {
-    var test = [1, 2, 3, 4]
+    let collection = [1, 2, 3, 4]
+    let singleValue = "hello"
 }

--- a/Tests/CohesionKitTests/Visitor/IdentityMapStoreVisitorTests.swift
+++ b/Tests/CohesionKitTests/Visitor/IdentityMapStoreVisitorTests.swift
@@ -60,7 +60,7 @@ private class EntityNodeStub<T>: EntityNode<T> {
     var observeChildKeyPathIndexCalled: (AnyEntityNode, PartialKeyPath<T>, Int) -> Void = { _, _, _ in }
     var observeChildKeyPathOptionalCalled: (AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
     
-    override func observeChild<C: BufferedCollection>(
+    override func observeChild<C: MutableCollection>(
         _ childNode: EntityNode<C.Element>,
         for keyPath: KeyPath<T, C>,
         index: C.Index


### PR DESCRIPTION
## ⚽️ Description

Support for `MutableCollection` without having to rely on `MutableAccelerateBuffer` protocol.

## 🔨 Implementation details

`MutableCollection` has actually a method defined to access the buffer: `withContiguousMutableStorageIfAvailable`. So just rely on it.

Also, avoid doing playing back and forth between `UnsafeMutablePointer` <-> `UnsafeMutableMutableRawPointer`: use the first one as much as possible.