### PR TITLE
fix(example): fixed random value generator returning initial value

### DIFF
--- a/Example/Example/Data/Data.swift
+++ b/Example/Example/Data/Data.swift
@@ -9,8 +9,9 @@ extension Market: ExpressibleByStringLiteral {
 }
 
 extension Outcome: ExpressibleByStringLiteral {
+    /// for the demo, init an outcome with odds at 0
     init(stringLiteral value: StringLiteralType) {
-        self.init(id: UUID().uuidString, name: value, odds: Double.random(in: 0...5))
+        self.init(id: UUID().uuidString, name: value, odds: 0)
     }
 }
 

--- a/Example/Example/Data/MatchRepository.swift
+++ b/Example/Example/Data/MatchRepository.swift
@@ -5,29 +5,30 @@ import CohesionKit
 class MatchRepository {
     private static let identityMap = IdentityMap()
     private lazy var identityMap = Self.identityMap
-    private var cancellables: Set<AnyCancellable> = []
-    
+
     /// load matches with their markets and outcomes from Data.swift
     func loadMatches() -> AnyPublisher<[MatchMarkets], Never> {
         let matches = MatchMarkets.simulatedMatches
-        
+
+        /// store the match and its markets into the identityMap
         return identityMap.store(entities: matches, modifiedAt: MatchMarkets.simulatedFetchedDate.stamp).asPublisher
     }
     
-    /// observe primary (first) match market changes (for this sample changes are generated randomely
+    /// observe primary (first) match market changes (for this sample changes are generated randomly)
     /// - Returns: the match with all its markets including updates for primary market
     func observePrimaryMarket(for match: Match) -> AnyPublisher<MatchMarkets, Never> {
-        let matchMarket = MatchMarkets.simulatedMatches.first { $0.match.id == match.id }!
+        let matchMarkets = MatchMarkets.simulatedMatches.first { $0.match.id == match.id }!
         var cancellables: Set<AnyCancellable> = []
         
-        for outcome in matchMarket.primaryMarket.outcomes {
+        for outcome in matchMarkets.primaryMarket.outcomes {
             generateRandomChanges(for: outcome)
                 .sink(receiveValue: { [identityMap] in
                     _ = identityMap.store(entity: $0)
                 })
                 .store(in: &cancellables)
         }
-        
+
+        /// for the test we consider that `loadMatches` was already called and thus markets already stored
         return identityMap.find(MatchMarkets.self, id: match.id)!
             .asPublisher
             .handleEvents(receiveCancel: { cancellables.removeAll() })
@@ -39,7 +40,6 @@ class MatchRepository {
             .publish(every: 3, on: .main, in: .common)
             .autoconnect()
             .map { _ in outcome.newOdds(Double.random(in: 0...25)) }
-            .prepend(outcome)
             .eraseToAnyPublisher()
     }
 

--- a/Example/Example/DetailsView.swift
+++ b/Example/Example/DetailsView.swift
@@ -32,8 +32,8 @@ struct MatchDetailsView: View {
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 0) {
-                Text("This view observe changes for primary market (1N2).")
-                Text("They are triggered every 3 secondes.")
+                Text("This view observe changes for the first market (1N2).")
+                Text("New values are triggered every 3 secondes.")
                 Text("If you go back you will see updated values on list view.")
             }
             .font(Font.footnote.italic())

--- a/Example/Example/Model.swift
+++ b/Example/Example/Model.swift
@@ -1,20 +1,24 @@
 import Foundation
 import CohesionKit
 
+/// A match is a sport game between two teams
 struct Match: Identifiable {
     let id: String
     let team1: String
     let team2: String
 }
 
+/// A market is a type of bet. For instance: who's going to win
 struct Market: Identifiable {
     let id: String
     let name: String
 }
 
+/// An outcome is a possible market outcome
 struct Outcome: Identifiable {
     let id: String
     let name: String
+    /// "probability" this outcome would happen
     let odds: Double
 
     func newOdds(_ odds: Double) -> Outcome {


### PR DESCRIPTION
## ⚽️ Description

Random value generator was prepending initial value which resetted the odds to their initial value.

## 🔨 Implementation details

- Remove prepend
- Initialize all odds to 0, which makes things a little bit clearer when they start changing