### PR TITLE
feat(collection): [#29] Allow for any kind of Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ identityMap.find(Book.self, id: 1)?
 
 ### Relational objects
 
-To store objects containing other objects you need to make them conform to one protocol: `Aggregate`.
+To store objects containing nested identity objects you need to make them conform to one protocol: `Aggregate`.
 
 ```swift
 struct AuthorBooks: Aggregate {
@@ -167,7 +167,7 @@ identityMap.find(Book.self, id: "ACK") // A Clash of Kings
 identityMap.find(Book.self, id: "ADD") // A Dance with Dragons
 ```
 
-You can also modify any of them however you want:
+You can also modify any of them however you want. Notice the change is visible from the object itself AND from aggregate objects:
 
 ```swift
 let newAuthor = Author(id: 1, name: "George R.R MartinI")
@@ -178,7 +178,7 @@ identityMap.find(Author.self, id: 1) // George R.R MartinI
 identityMap.find(AuthorBooks.self, id: 1) // George R.R MartinI + [A Clash of Kings, A Dance with Dragons]
 ```
 
-> You might think about storing books on `Author` directly (`author.books`). In this case `Author` would need to implement `Aggregate` and declare `books` are nested entity.
+> You might think about storing books on `Author` directly (`author.books`). In this case `Author` needs to implement `Aggregate` and declare `books` as nested entity.
 >
 > However I strongly advise you to not nest `Identifiable` objects into other `Identifiable` objects. Read [Handling relationships](https://swiftunwrap.com/article/modeling-done-right/) article if you want to know more about this subject.
 
@@ -268,10 +268,6 @@ identityMap.find(Book.self, id: "ACK") // return "A Clash of Kings" because canc
 ```
 
 ## Known limitations
-
-### Custom collections are not supported
-
-Custom collections are actually supported but for now you need to import `Accelerate` and conform to `AccelerateMutableBuffer`. Hopefully this restriction will be lifted.
 
 ### Associated value enums require double update
 

--- a/Sources/CohesionKit/KeyPath/PartialIdentifiableKeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/PartialIdentifiableKeyPath.swift
@@ -45,7 +45,7 @@ public struct PartialIdentifiableKeyPath<Root> {
         }
     }
     
-    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Identifiable, C.Index == Int {
+    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Identifiable, C.Index: Hashable {
         self.keyPath = keyPath
         self.accept = { parent, root, stamp, visitor in
             visitor.visit(
@@ -55,7 +55,7 @@ public struct PartialIdentifiableKeyPath<Root> {
         }
     }
     
-    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Aggregate, C.Index == Int {
+    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Aggregate, C.Index: Hashable {
         self.keyPath = keyPath
         self.accept = { parent, root, stamp, visitor in
             visitor.visit(

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -61,7 +61,7 @@ class EntityNode<T>: AnyEntityNode {
     
     /// observe one of the node child whose type is a collection
     func observeChild<C: MutableCollection>(_ childNode: EntityNode<C.Element>, for keyPath: KeyPath<T, C>, index: C.Index)
-    where C.Index == Int {
+    where C.Index: Hashable {
         observeChild(childNode, identity: keyPath.appending(path: \C[index])) { pointer, newValue in
             pointer.assign(newValue, to: keyPath, index: index)
         }

--- a/Sources/CohesionKit/Visitor/IdentityMapStoreVisitor.swift
+++ b/Sources/CohesionKit/Visitor/IdentityMapStoreVisitor.swift
@@ -33,7 +33,7 @@ struct IdentityMapStoreVisitor: NestedEntitiesVisitor {
     }
     
     func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
-    where C.Element: Identifiable, C.Index == Int {
+    where C.Element: Identifiable, C.Index: Hashable {
         
         for index in entities.indices {
             context.parent.observeChild(
@@ -45,7 +45,7 @@ struct IdentityMapStoreVisitor: NestedEntitiesVisitor {
     }
     
     func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
-    where C.Element: Aggregate, C.Index == Int {
+    where C.Element: Aggregate, C.Index: Hashable {
         
         for index in entities.indices {
             context.parent.observeChild(

--- a/Sources/CohesionKit/Visitor/NestedEntitiesVisitor.swift
+++ b/Sources/CohesionKit/Visitor/NestedEntitiesVisitor.swift
@@ -9,8 +9,8 @@ protocol NestedEntitiesVisitor {
     func visit<Root, T: Aggregate>(context: EntityContext<Root, T?>, entity: T?)
     
     func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
-    where C.Element: Identifiable, C.Index == Int
+    where C.Element: Identifiable, C.Index: Hashable
     
     func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
-    where C.Element: Aggregate, C.Index == Int
+    where C.Element: Aggregate, C.Index: Hashable
 }

--- a/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
+++ b/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class UnsafeMutablePointerTests: XCTestCase {
     func test_assign_propertyIsImmutable_propertyIsChanged() {
-        var hello = Hello()
+        var hello = Hello(collection: [], singleValue: "hello")
 
         withUnsafeMutablePointer(to: &hello) {
             $0.assign("world", to: \Hello.singleValue)
@@ -13,7 +13,7 @@ class UnsafeMutablePointerTests: XCTestCase {
     }
 
     func test_assign_keyPathIsCollection_propertyIsImmutable_collectionIsChangedAtIndex() {
-        var hello = Hello()
+        var hello = Hello(collection: [1, 2, 3, 4], singleValue: "")
 
         withUnsafeMutablePointer(to: &hello) {            
             $0.assign(5, to: \Hello.collection, index: 3)
@@ -21,9 +21,21 @@ class UnsafeMutablePointerTests: XCTestCase {
         
         XCTAssertEqual(hello.collection, [1, 2, 3, 5])
     }
+
+    func test_assign_keyPathIsCollection_mutipleAssignments_colllectionIsChanged() {
+        var hello = Hello(collection: [1, 2, 3, 4], singleValue: "")
+
+        withUnsafeMutablePointer(to: &hello) {
+            $0.assign(4, to: \Hello.collection, index: 0)
+            $0.assign(3, to: \Hello.collection, index: 0)
+            $0.assign(2, to: \Hello.collection, index: 0)
+        }
+
+        XCTAssertEqual(hello.collection, [2, 2, 3, 4])
+    }
 }
 
 private struct Hello {
-    let collection = [1, 2, 3, 4]
-    let singleValue = "hello"
+    let collection: [Int]
+    let singleValue: String
 }

--- a/Tests/CohesionKitTests/Visitor/IdentityMapStoreVisitorTests.swift
+++ b/Tests/CohesionKitTests/Visitor/IdentityMapStoreVisitorTests.swift
@@ -57,14 +57,14 @@ class IdentityMapStoreVisitorTests: XCTestCase {
 }
 
 private class EntityNodeStub<T>: EntityNode<T> {
-    var observeChildKeyPathIndexCalled: (AnyEntityNode, PartialKeyPath<T>, Int) -> Void = { _, _, _ in }
+    var observeChildKeyPathIndexCalled: (AnyEntityNode, PartialKeyPath<T>, Any) -> Void = { _, _, _ in }
     var observeChildKeyPathOptionalCalled: (AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
     
     override func observeChild<C: MutableCollection>(
         _ childNode: EntityNode<C.Element>,
         for keyPath: KeyPath<T, C>,
         index: C.Index
-    ) where C.Index == Int {
+    ) {
         observeChildKeyPathIndexCalled(childNode, keyPath, index)
     }
     


### PR DESCRIPTION
## ⚽️ Description

Lift restriction on `MutableCollection.Index` to be an `Int`. Now only requirement is `Index` being `Hashable`.

## 🔨 Implementation details

- Position to update value in raw buffer is now computed using `distance(from:to:)`
- Update README to remove section about limitations on collections

We can now close #29 