### PR TITLE
fix(collection): Fixed assign not working with custom collection

### DIFF
--- a/Sources/CohesionKit/KeyPath/PartialIdentifiableKeyPath.swift
+++ b/Sources/CohesionKit/KeyPath/PartialIdentifiableKeyPath.swift
@@ -45,7 +45,7 @@ public struct PartialIdentifiableKeyPath<Root> {
         }
     }
     
-    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Identifiable, C.Index: Hashable {
+    public init<C: BufferedCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Identifiable, C.Index: Hashable {
         self.keyPath = keyPath
         self.accept = { parent, root, stamp, visitor in
             visitor.visit(
@@ -55,7 +55,7 @@ public struct PartialIdentifiableKeyPath<Root> {
         }
     }
     
-    public init<C: MutableCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Aggregate, C.Index: Hashable {
+    public init<C: BufferedCollection>(_ keyPath: KeyPath<Root, C>) where C.Element: Aggregate, C.Index: Hashable {
         self.keyPath = keyPath
         self.accept = { parent, root, stamp, visitor in
             visitor.visit(

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -60,7 +60,7 @@ class EntityNode<T>: AnyEntityNode {
     }
     
     /// observe one of the node child whose type is a collection
-    func observeChild<C: MutableCollection>(_ childNode: EntityNode<C.Element>, for keyPath: KeyPath<T, C>, index: C.Index)
+    func observeChild<C: BufferedCollection>(_ childNode: EntityNode<C.Element>, for keyPath: KeyPath<T, C>, index: C.Index)
     where C.Index: Hashable {
         observeChild(childNode, identity: keyPath.appending(path: \C[index])) { pointer, newValue in
             pointer.assign(newValue, to: keyPath, index: index)

--- a/Sources/CohesionKit/UnsafePointer/BufferedCollection.swift
+++ b/Sources/CohesionKit/UnsafePointer/BufferedCollection.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A collection providing an access to its buffer.
+/// 
+/// Idea was to directly use `BufferedCollection.withContiguousStorageIfAvailable`` **but default implementation returns nil**
+/// (see https://github.com/apple/swift-evolution/blob/main/proposals/0237-contiguous-collection.md)
+public protocol BufferedCollection: Collection {
+    /// Provides an access to collection inner buffer.
+    /// 
+    /// Don't forward to `withContiguousStorageIfAvailable` which default implementation returns nil 🤦‍♂️
+    mutating func withUnsafeMutableBufferPointer<R>(_ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R) rethrows -> R
+}
+
+extension Array: BufferedCollection { }

--- a/Sources/CohesionKit/UnsafePointer/UnsafeMutablePointer+KeyPath.swift
+++ b/Sources/CohesionKit/UnsafePointer/UnsafeMutablePointer+KeyPath.swift
@@ -11,7 +11,7 @@ extension UnsafeMutablePointer {
         unsafeValuePointer.pointee = value
     }
 
-    func assign<C: MutableCollection>(_ value: C.Element, to keyPath: KeyPath<Pointee, C>, index: C.Index) {
+    func assign<C: BufferedCollection>(_ value: C.Element, to keyPath: KeyPath<Pointee, C>, index: C.Index) {
 
         guard let unsafeCollectionPointer = UnsafeMutablePointer<C>(mutating: pointer(to: keyPath)) else {
             fatalError("cannot update value for KeyPath<\(Pointee.self), \(C.self)>: failed to access memory pointer.")
@@ -22,6 +22,6 @@ extension UnsafeMutablePointer {
             .pointee
             .distance(from: unsafeCollectionPointer.pointee.startIndex, to: index)
 
-        unsafeCollectionPointer.pointee.withContiguousMutableStorageIfAvailable { $0[distance] = value }
+        unsafeCollectionPointer.pointee.withUnsafeMutableBufferPointer { $0[distance] = value }
     }
 }

--- a/Sources/CohesionKit/Visitor/IdentityMapStoreVisitor.swift
+++ b/Sources/CohesionKit/Visitor/IdentityMapStoreVisitor.swift
@@ -32,7 +32,7 @@ struct IdentityMapStoreVisitor: NestedEntitiesVisitor {
         }
     }
     
-    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Identifiable, C.Index: Hashable {
         
         for index in entities.indices {
@@ -44,7 +44,7 @@ struct IdentityMapStoreVisitor: NestedEntitiesVisitor {
         }
     }
     
-    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Aggregate, C.Index: Hashable {
         
         for index in entities.indices {

--- a/Sources/CohesionKit/Visitor/NestedEntitiesVisitor.swift
+++ b/Sources/CohesionKit/Visitor/NestedEntitiesVisitor.swift
@@ -8,9 +8,9 @@ protocol NestedEntitiesVisitor {
     func visit<Root, T: Identifiable>(context: EntityContext<Root, T?>, entity: T?)
     func visit<Root, T: Aggregate>(context: EntityContext<Root, T?>, entity: T?)
     
-    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Identifiable, C.Index: Hashable
     
-    func visit<Root, C: MutableCollection>(context: EntityContext<Root, C>, entities: C)
+    func visit<Root, C: BufferedCollection>(context: EntityContext<Root, C>, entities: C)
     where C.Element: Aggregate, C.Index: Hashable
 }

--- a/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
+++ b/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
@@ -12,7 +12,7 @@ class UnsafeMutablePointerTests: XCTestCase {
         XCTAssertEqual(hello.singleValue, "world")
     }
 
-    func test_assign_keyPathIsCollection_propertyIsImmutable_collectionIsChangedAtIndex() {
+    func test_assign_keyPathIsArray_propertyIsImmutable_arrayIsChanged() {
         var hello = Hello(collection: [1, 2, 3, 4], singleValue: "")
 
         withUnsafeMutablePointer(to: &hello) {            
@@ -22,7 +22,7 @@ class UnsafeMutablePointerTests: XCTestCase {
         XCTAssertEqual(hello.collection, [1, 2, 3, 5])
     }
 
-    func test_assign_keyPathIsCollection_mutipleAssignments_colllectionIsChanged() {
+    func test_assign_keyPathIsArray_mutipleAssignments_arrayIsChanged() {
         var hello = Hello(collection: [1, 2, 3, 4], singleValue: "")
 
         withUnsafeMutablePointer(to: &hello) {
@@ -33,9 +33,51 @@ class UnsafeMutablePointerTests: XCTestCase {
 
         XCTAssertEqual(hello.collection, [2, 2, 3, 4])
     }
+
+    func test_assign_keyPathIsCustomCollection_colectionIsChanged() {
+        var hello = Hello(collection: [], singleValue: "")
+
+        hello.myCollection = ["1", "2"]
+
+        withUnsafeMutablePointer(to: &hello) {
+            $0.assign("3", to: \.myCollection, index: 0)
+            $0.assign("4", to: \.myCollection, index: 0)
+        }
+
+        XCTAssertEqual(hello.myCollection, ["3", "4"])
+    }
 }
 
 private struct Hello {
     let collection: [Int]
     let singleValue: String
+    var myCollection: MyCollection = []
+}
+
+struct MyCollection: MutableCollection, Equatable, ExpressibleByArrayLiteral {
+    typealias Element = Array<String>.Element
+    typealias Index = Array<String>.Index
+
+    var elements: [String] = []
+
+    var startIndex: Index { elements.startIndex }
+
+    var endIndex: Index { elements.endIndex }
+
+    init(arrayLiteral elements: String...) {
+        self.elements = elements
+    }
+
+    subscript(position: Index) -> Element {
+        get { 
+            elements[position]
+        }
+        set(newValue) {
+            elements[position] = newValue
+        }
+    }
+
+    func index(after i: Index) -> Index {
+        elements.index(after: i)
+    }
 }

--- a/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
+++ b/Tests/CohesionKitTests/KeyPath/UnsafeMutablePointerTests.swift
@@ -54,7 +54,7 @@ private struct Hello {
     var myCollection: MyCollection = []
 }
 
-struct MyCollection: MutableCollection, Equatable, ExpressibleByArrayLiteral {
+struct MyCollection: BufferedCollection, Equatable, ExpressibleByArrayLiteral {
     typealias Element = Array<String>.Element
     typealias Index = Array<String>.Index
 
@@ -79,5 +79,9 @@ struct MyCollection: MutableCollection, Equatable, ExpressibleByArrayLiteral {
 
     func index(after i: Index) -> Index {
         elements.index(after: i)
+    }
+
+    func withUnsafeMutableBufferPointer(_ body: (inout UnsafeMutableBufferPointer<Array<String>.Element>) throws -> Void) rethrows {
+        try elements.withUnsafeBufferPointer(body)
     }
 }

--- a/Tests/CohesionKitTests/UnsafePointer/UnsafeMutablePointerTests.swift
+++ b/Tests/CohesionKitTests/UnsafePointer/UnsafeMutablePointerTests.swift
@@ -15,10 +15,10 @@ class UnsafeMutablePointerTests: XCTestCase {
     func test_assign_keyPathIsArray_propertyIsImmutable_arrayIsChanged() {
         var hello = Hello(collection: [1, 2, 3, 4], singleValue: "")
 
-        withUnsafeMutablePointer(to: &hello) {            
+        withUnsafeMutablePointer(to: &hello) {
             $0.assign(5, to: \Hello.collection, index: 3)
         }
-        
+
         XCTAssertEqual(hello.collection, [1, 2, 3, 5])
     }
 
@@ -41,7 +41,7 @@ class UnsafeMutablePointerTests: XCTestCase {
 
         withUnsafeMutablePointer(to: &hello) {
             $0.assign("3", to: \.myCollection, index: 0)
-            $0.assign("4", to: \.myCollection, index: 0)
+            $0.assign("4", to: \.myCollection, index: 1)
         }
 
         XCTAssertEqual(hello.myCollection, ["3", "4"])
@@ -69,7 +69,7 @@ struct MyCollection: BufferedCollection, Equatable, ExpressibleByArrayLiteral {
     }
 
     subscript(position: Index) -> Element {
-        get { 
+        get {
             elements[position]
         }
         set(newValue) {
@@ -81,7 +81,7 @@ struct MyCollection: BufferedCollection, Equatable, ExpressibleByArrayLiteral {
         elements.index(after: i)
     }
 
-    func withUnsafeMutableBufferPointer(_ body: (inout UnsafeMutableBufferPointer<Array<String>.Element>) throws -> Void) rethrows {
-        try elements.withUnsafeBufferPointer(body)
+    mutating func withUnsafeMutableBufferPointer<R>(_ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R) rethrows -> R {
+        try elements.withUnsafeMutableBufferPointer(body)
     }
 }

--- a/Tests/CohesionKitTests/Visitor/IdentityMapStoreVisitorTests.swift
+++ b/Tests/CohesionKitTests/Visitor/IdentityMapStoreVisitorTests.swift
@@ -60,7 +60,7 @@ private class EntityNodeStub<T>: EntityNode<T> {
     var observeChildKeyPathIndexCalled: (AnyEntityNode, PartialKeyPath<T>, Any) -> Void = { _, _, _ in }
     var observeChildKeyPathOptionalCalled: (AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
     
-    override func observeChild<C: MutableCollection>(
+    override func observeChild<C: BufferedCollection>(
         _ childNode: EntityNode<C.Element>,
         for keyPath: KeyPath<T, C>,
         index: C.Index


### PR DESCRIPTION
## ⚽️ Description

So I was too confident with previous MR and MutableCollection (#38). It turns out `withContiguousMutableStorageIfAvailable` [default implementation returns nil](https://github.com/apple/swift-evolution/blob/main/proposals/0237-contiguous-collection.md)! 🤦 

In result it was working perfectly fine with Array but not with custom collections...

## 🔨 Implementation details

- Added a test with custom collection to avoid any future regression on this usecase
- Introduced back `BufferedCollection` :(. But this time as a protocol so we still are independent from Accelerate