### PR TITLE
tech(observer): Rename Ref -> Observable

### DIFF
--- a/Sources/CohesionKit/Observer/AliasObserver.swift
+++ b/Sources/CohesionKit/Observer/AliasObserver.swift
@@ -3,27 +3,27 @@ import Foundation
 // A type registering observers over an aliased entity
 public struct AliasObserver<T>: Observer {
     typealias OnChangeClosure = (T?) -> Void
-    
+
     public var value: T?
     /// a closure redirecting to the right observe method depending on T type
     let createObserve: (@escaping OnChangeClosure) -> Subscription
-    
+
     /// create an observer for a single entity node ref
-    init(alias: Ref<EntityNode<T>?>, queue: DispatchQueue) {
+    init(alias: Observable<EntityNode<T>?>, queue: DispatchQueue) {
         self.value = alias.value?.ref.value
         self.createObserve = {
             Self.createObserve(for: alias, queue: queue, onChange: $0)
         }
     }
-    
+
     /// create an observer for a list of node ref
-    init<E>(alias: Ref<[EntityNode<E>]?>, queue: DispatchQueue) where T == Array<E> {
+    init<E>(alias: Observable<[EntityNode<E>]?>, queue: DispatchQueue) where T == Array<E> {
         self.value = alias.value?.map(\.ref.value)
         self.createObserve = {
             Self.createObserve(for: alias, queue: queue, onChange: $0)
         }
     }
-    
+
     public func observe(onChange: @escaping (T?) -> Void) -> Subscription {
         createObserve(onChange)
     }
@@ -34,7 +34,7 @@ extension AliasObserver {
     /// - the ref node change
     /// - the ref node value change
     private static func createObserve(
-        for alias: Ref<EntityNode<T>?>,
+        for alias: Observable<EntityNode<T>?>,
         queue: DispatchQueue,
         onChange: @escaping OnChangeClosure
     ) -> Subscription {
@@ -62,7 +62,7 @@ extension AliasObserver {
     /// - the ref node change
     /// - any of the ref node element change
   private static func createObserve<E>(
-        for alias: Ref<[EntityNode<E>]?>,
+        for alias: Observable<[EntityNode<E>]?>,
         queue: DispatchQueue,
         onChange: @escaping OnChangeClosure
     ) -> Subscription where T == Array<E> {

--- a/Sources/CohesionKit/Observer/Observable.swift
+++ b/Sources/CohesionKit/Observer/Observable.swift
@@ -2,19 +2,19 @@ import Foundation
 
 public class Subscription {
     public let unsubscribe: () -> Void
-    
+
     init(unsubscribe: @escaping () -> Void) {
         var unsubscribed = false
-        
+
         self.unsubscribe = {
             if !unsubscribed {
                 unsubscribe()
             }
-            
+
             unsubscribed = true
         }
     }
-    
+
     deinit {
         unsubscribe()
     }
@@ -22,25 +22,26 @@ public class Subscription {
 
 protocol AnyRef { }
 
-/// A class holding a value
-class Ref<T>: AnyRef {
-    
+/// A class holding a value that can be observed when reference changes
+class Observable<T>: AnyRef {
+    typealias ObserverID = UUID
+
     var value: T {
         didSet {
             observers.values.forEach { $0(value) }
         }
     }
     private var observers: [UUID: (T) -> Void] = [:]
-    
+
     init(value: T) {
         self.value = value
     }
-    
+
     func addObserver(onChange: @escaping (T) -> Void) -> Subscription {
         let uuid = UUID()
-        
+
         observers[uuid] = onChange
-        
+
         return Subscription {
             self.observers.removeValue(forKey: uuid)
         }

--- a/Sources/CohesionKit/Observer/Observable.swift
+++ b/Sources/CohesionKit/Observer/Observable.swift
@@ -20,10 +20,11 @@ public class Subscription {
     }
 }
 
-protocol AnyRef { }
+/// marker protocol
+protocol AnyObservable { }
 
 /// A class holding a value that can be observed when reference changes
-class Observable<T>: AnyRef {
+class Observable<T>: AnyObservable {
     typealias ObserverID = UUID
 
     var value: T {

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -1,5 +1,5 @@
 /// Keep a strong reference on each aliased node
-typealias AliasStorage = [AnyHashable: AnyRef]
+typealias AliasStorage = [AnyHashable: AnyObservable]
 
 extension AliasStorage {
     subscript<T>(key: AliasKey<T>) -> Observable<EntityNode<T>?> {

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -2,13 +2,13 @@
 typealias AliasStorage = [AnyHashable: AnyRef]
 
 extension AliasStorage {
-    subscript<T>(key: AliasKey<T>) -> Ref<EntityNode<T>?> {
+    subscript<T>(key: AliasKey<T>) -> Observable<EntityNode<T>?> {
         mutating get {
-            if let store = self[AnyHashable(key)] as? Ref<EntityNode<T>?> {
+            if let store = self[AnyHashable(key)] as? Observable<EntityNode<T>?> {
                 return store
             }
 
-            let store: Ref<EntityNode<T>?> = Ref(value: nil)
+            let store: Observable<EntityNode<T>?> = Observable(value: nil)
             self[AnyHashable(key)] = store
 
             return store
@@ -16,13 +16,13 @@ extension AliasStorage {
         }
     }
 
-    subscript<C: Collection>(key: AliasKey<C>) -> Ref<[EntityNode<C.Element>]?> {
+    subscript<C: Collection>(key: AliasKey<C>) -> Observable<[EntityNode<C.Element>]?> {
         mutating get {
-            if let store = self[AnyHashable(key)] as? Ref<[EntityNode<C.Element>]?> {
+            if let store = self[AnyHashable(key)] as? Observable<[EntityNode<C.Element>]?> {
                 return store
             }
 
-            let store: Ref<[EntityNode<C.Element>]?> = Ref(value: nil)
+            let store: Observable<[EntityNode<C.Element>]?> = Observable(value: nil)
             self[AnyHashable(key)] = store
 
             return store
@@ -39,10 +39,10 @@ extension AliasStorage {
     }
 
     mutating func remove<T>(for key: AliasKey<T>) {
-        (self[AnyHashable(key)] as? Ref<EntityNode<T>?>)?.value = nil
+        (self[AnyHashable(key)] as? Observable<EntityNode<T>?>)?.value = nil
     }
 
     mutating func remove<C: Collection>(for key: AliasKey<C>) {
-        (self[AnyHashable(key)] as? Ref<[EntityNode<C.Element>]?>)?.value = nil
+        (self[AnyHashable(key)] as? Observable<[EntityNode<C.Element>]?>)?.value = nil
     }
 }

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -21,20 +21,20 @@ class EntityNode<T>: AnyEntityNode {
     var value: Any { ref.value }
 
     /// An observable entity reference
-    let ref: Ref<T>
+    let ref: Observable<T>
     /// last time the ref.value was changed. Any subsequent change must have a higher value to be applied
     /// if nil ref has no stamp and any change will be accepted
     private var modifiedAt: Stamp?
     /// entity children
     private(set) var children: [PartialKeyPath<T>: SubscribedChild] = [:]
 
-    init(ref: Ref<T>, modifiedAt: Stamp?) {
+    init(ref: Observable<T>, modifiedAt: Stamp?) {
         self.ref = ref
         self.modifiedAt = modifiedAt
     }
 
     convenience init(_ entity: T, modifiedAt: Stamp?) {
-        self.init(ref: Ref(value: entity), modifiedAt: modifiedAt)
+        self.init(ref: Observable(value: entity), modifiedAt: modifiedAt)
     }
 
     /// change the entity to a new value only if `modifiedAt` is equal than any previous registered modification

--- a/Tests/CohesionKitTests/Observer/AliasObserverTests.swift
+++ b/Tests/CohesionKitTests/Observer/AliasObserverTests.swift
@@ -3,28 +3,28 @@ import XCTest
 
 class AliasObserverTests: XCTestCase {
     func test_observe_refValueChanged_onChangeIsCalled() {
-        let ref = Ref(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
+        let ref = Observable(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
         let observer = AliasObserver(alias: ref, queue: .main)
         let newValue = SingleNodeFixture(id: 2)
         var lastReceivedValue: SingleNodeFixture?
         let expectation = XCTestExpectation()
-        
+
         let subscription = observer.observe {
             lastReceivedValue = $0
             expectation.fulfill()
         }
-        
+
         withExtendedLifetime(subscription) {
             ref.value = EntityNode(newValue, modifiedAt: 0)
         }
-        
+
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(lastReceivedValue, newValue)
     }
 
     func test_observe_entityIsUpdated_onChangeIsCalled() throws {
       let node = EntityNode(RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 0), listNodes: []), modifiedAt: 0)
-      let observer = AliasObserver(alias: Ref(value: node), queue: .main)
+      let observer = AliasObserver(alias: Observable(value: node), queue: .main)
       let newValue = RootFixture(id: 1, primitive: "new value", singleNode: SingleNodeFixture(id: 1), listNodes: [])
       var lastObservedValue: RootFixture?
       let expectation = XCTestExpectation()
@@ -43,31 +43,31 @@ class AliasObserverTests: XCTestCase {
     }
 
     func test_observe_refValueChanged_entityIsUpdated_onChangeIsCalled() throws {
-        let ref = Ref(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
+        let ref = Observable(value: Optional.some(EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0)))
         let observer = AliasObserver(alias: ref, queue: .main)
         let newNode = EntityNode(SingleNodeFixture(id: 2), modifiedAt: 0)
         let newValue = SingleNodeFixture(id: 3)
         var lastReceivedValue: SingleNodeFixture?
         let expectation = XCTestExpectation()
-        
+
         let subscription = observer.observe {
             lastReceivedValue = $0
             expectation.fulfill()
         }
-        
+
         try withExtendedLifetime(subscription) {
             ref.value = newNode
             try newNode.updateEntity(newValue, modifiedAt: 1)
         }
-        
+
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(lastReceivedValue, newValue)
     }
-    
+
     func test_observe_subscriptionIsCancelled_unsubscribeToUpdates() throws {
         let initialValue = SingleNodeFixture(id: 1)
         let node = EntityNode(initialValue, modifiedAt: 0)
-        let ref = Ref(value: Optional.some(node))
+        let ref = Observable(value: Optional.some(node))
         let observer = AliasObserver(alias: ref, queue: .main)
         let newValue = SingleNodeFixture(id: 3)
         var lastReceivedValue: SingleNodeFixture?
@@ -87,7 +87,7 @@ class AliasObserverTests: XCTestCase {
             EntityNode(SingleNodeFixture(id: 1), modifiedAt: 0),
             EntityNode(SingleNodeFixture(id: 2), modifiedAt: 0)
         ]
-        let ref = Ref(value: Optional.some(nodes))
+        let ref = Observable(value: Optional.some(nodes))
         let observer = AliasObserver(alias: ref, queue: .main)
         let update = SingleNodeFixture(id: 1, primitive: "Update")
         var lastObservedValue: [SingleNodeFixture]?

--- a/Tests/CohesionKitTests/RefTests.swift
+++ b/Tests/CohesionKitTests/RefTests.swift
@@ -3,38 +3,38 @@ import XCTest
 
 class RefTests: XCTestCase {
     func test_addObserver_valueChange_observerIsCalled() {
-        let ref = Ref(value: "hello")
+        let ref = Observable(value: "hello")
         var receivedValue: String? = nil
         let subscription = ref.addObserver {
             receivedValue = $0
         }
-        
+
         ref.value = "hello world"
-        
+
         XCTAssertEqual(receivedValue, "hello world")
-        
+
         subscription.unsubscribe() // just to avoid warning on non used variable
     }
-    
+
     func test_addObserver_whenUnsubscribing_valueChange_observerIsNotCalled() {
-        let ref = Ref(value: "hello")
-        
+        let ref = Observable(value: "hello")
+
         let subscription = ref.addObserver { _ in
             XCTFail("subscription was canceled: should not have been called")
         }
-        
+
         subscription.unsubscribe()
-        
+
         ref.value = "hello world"
     }
-    
+
     func test_addObserver_subscribingIsDealloc_valueChange_observerIsNotCalled() {
-        let ref = Ref(value: "hello")
-        
+        let ref = Observable(value: "hello")
+
         _ = ref.addObserver { _ in
             XCTFail("subscription was release: should not have been called")
         }
-        
+
         ref.value = "hello world"
     }
 }

--- a/Tests/CohesionKitTests/Storage/AliasStorageTests.swift
+++ b/Tests/CohesionKitTests/Storage/AliasStorageTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import CohesionKit
 
 class AliasStorageTests: XCTestCase {
-    func test_subscriptGet_aliasIsCollection_noValue_returnRef() {
+    func test_subscriptGet_aliasIsCollection_noValue_returnObservable() {
         var storage: AliasStorage = [:]
 
         XCTAssertNotNil(storage[.testCollection])
@@ -30,7 +30,7 @@ class AliasStorageTests: XCTestCase {
     func test_remove_aliasInsertedBefore_itRemovesValue() {
         var storage: AliasStorage = [:]
 
-        storage.insert(EntityNode(ref: Ref(value: 1), modifiedAt: nil), key: .test)
+        storage.insert(EntityNode(ref: Observable(value: 1), modifiedAt: nil), key: .test)
         storage.remove(for: .test)
 
         XCTAssertNil(storage[.test].value)

--- a/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
+++ b/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
@@ -10,7 +10,7 @@ class EntityNodeTests: XCTestCase {
         listNodes: []
     )
     let startTimestamp: Stamp = 0
-    
+
     let newEntity = RootFixture(
         id: 1,
         primitive: "hello world",
@@ -18,76 +18,76 @@ class EntityNodeTests: XCTestCase {
         optional: nil,
         listNodes: []
     )
-    
+
     var node: EntityNode<RootFixture>!
-    
+
     override func setUp() {
         node = EntityNode(startEntity, modifiedAt: startTimestamp)
     }
-    
+
     func test_updateEntity_stampIsEqual_entityIsNotUpdated() throws {
         XCTAssertThrowsError(
             try node.updateEntity(newEntity, modifiedAt: startTimestamp)
         )
-        
+
         XCTAssertEqual(node.value as? RootFixture, startEntity)
     }
-    
+
     func test_updateEntity_stampIsSup_entityIsUpdated() throws {
         try node.updateEntity(newEntity, modifiedAt: startTimestamp + 1)
-        
+
         XCTAssertEqual(node.value as? RootFixture, newEntity)
     }
-    
+
     func test_updateEntity_stampIsInf_entityIsNotUpdated() throws {
         XCTAssertThrowsError(
             try node.updateEntity(newEntity, modifiedAt: startTimestamp - 1)
         )
-        
+
         XCTAssertEqual(node.value as? RootFixture, startEntity)
     }
-    
+
     func test_observeChild_childChange_entityIsUpdated() throws {
         let childNode = EntityNode(startEntity.singleNode, modifiedAt: 0)
         let newChild = SingleNodeFixture(id: 1, primitive: "updated")
-        
+
         node.observeChild(childNode, for: \.singleNode)
-        
+
         try childNode.updateEntity(newChild, modifiedAt: 1)
-        
+
         XCTAssertEqual((node.value as? RootFixture)?.singleNode, newChild)
     }
-    
+
     func test_observeChild_childChange_entityObserversAreCalled() throws {
         let childNode = EntityNode(startEntity.singleNode, modifiedAt: startTimestamp)
         let newChild = SingleNodeFixture(id: 1, primitive: "updated")
-        let entityRef = Ref(value: startEntity)
+        let entityRef = Observable(value: startEntity)
         var observerCalled = false
-        
+
         let subscription = entityRef.addObserver { _ in
             observerCalled = true
         }
-        
+
         node = EntityNode(ref: entityRef, modifiedAt: startTimestamp)
         node.observeChild(childNode, for: \.singleNode)
-        
+
         try childNode.updateEntity(newChild, modifiedAt: startTimestamp + 1)
-        
+
         subscription.unsubscribe()
-        
+
         XCTAssertTrue(observerCalled)
     }
-    
+
     func test_observeChildIndex_eachChildIsAdded() {
         let child1 = EntityNode(ListNodeFixture(id: 1), modifiedAt: startTimestamp)
         let child2 = EntityNode(ListNodeFixture(id: 2), modifiedAt: startTimestamp)
         let node = EntityNode(startEntity, modifiedAt: startTimestamp)
-        
+
         XCTAssertEqual(node.children.count, 0)
-        
+
         node.observeChild(child1, for: \.listNodes, index: 0)
         node.observeChild(child2, for: \.listNodes, index: 1)
-        
+
         XCTAssertEqual(node.children.count, 2)
     }
 }


### PR DESCRIPTION
## ⚽️ Description

Rename Ref -> Observable as it seems to be a more appropriate name: it conveys the objective of the class.

## 🔨 Implementation details

- Renamed Ref -> Observable
- Renamed AnyRef -> AnyObservable