### PR TITLE
tech(store): Ignore multiple changes to same entity while storing/updating

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -154,6 +154,10 @@ public class IdentityMap {
             registry.enqueueChange(for: $0)
         }]
 
+        guard !registry.hasPendingChange(for: node) else {
+            return node
+        }
+
         do {
             try node.updateEntity(entity, modifiedAt: modifiedAt)
             logger?.didStore(T.self, id: entity.id)
@@ -169,6 +173,10 @@ public class IdentityMap {
         let node = storage[entity, new: EntityNode(entity, modifiedAt: nil) { [registry] in
             registry.enqueueChange(for: $0)
         }]
+
+        guard !registry.hasPendingChange(for: node) else {
+            return node
+        }
 
         // clear all children to avoid a removed child to be kept as child
         node.removeAllChildren()

--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -170,17 +170,12 @@ public class IdentityMap {
             registry.enqueueChange(for: $0)
         }]
 
-        // disable changes while doing the entity update
-        node.applyChildrenChanges = false
-
         // clear all children to avoid a removed child to be kept as child
         node.removeAllChildren()
 
         for keyPathContainer in entity.nestedEntitiesKeyPaths {
             keyPathContainer.accept(node, entity, modifiedAt, storeVisitor)
         }
-
-        node.applyChildrenChanges = true
 
         do {
             try node.updateEntity(entity, modifiedAt: modifiedAt)

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -17,7 +17,6 @@ class EntityNode<T>: AnyEntityNode {
         let node: AnyEntityNode
     }
 
-    var applyChildrenChanges = true
     var value: Any { ref.value }
 
     /// An observable entity reference
@@ -85,10 +84,6 @@ class EntityNode<T>: AnyEntityNode {
         }
 
         let subscription = childNode.ref.addObserver { [unowned self] newValue in
-            guard self.applyChildrenChanges else {
-                return
-            }
-
             update(&self.ref.value, newValue)
             self.onChange?(self)
         }

--- a/Tests/CohesionKitTests/Observer/Stub/ObserverRegistryStub.swift
+++ b/Tests/CohesionKitTests/Observer/Stub/ObserverRegistryStub.swift
@@ -3,6 +3,7 @@
 /// An ObserverRegistry stub: all methods have default behaviour. Some can be mocked and some can be tracked
 class ObserverRegistryStub: ObserverRegistry {
     var enqueueChangeCalled: (AnyHashable) -> Void = { _ in }
+    /// Enqueued changes. Not typed. A same change could be enqueue multiple times (for testing purposes!)
     private var pendingChangesStub: [Any] = []
 
 
@@ -14,5 +15,10 @@ class ObserverRegistryStub: ObserverRegistry {
 
     func hasPendingChange<T: Equatable>(for entity: T) -> Bool {
         pendingChangesStub.contains { ($0 as? EntityNode<T>)?.ref.value == entity }
+    }
+
+    /// number of times change has been inserted for this entity
+    func pendingChangeCount<T: Equatable>(for entity: T) -> Int {
+        pendingChangesStub.filter { ($0 as? EntityNode<T>)?.ref.value == entity }.count
     }
 }


### PR DESCRIPTION
## ⚽️ Description

Part of #48. Now if an entity is changed multiple times while storing it will be change only once (the first time).

This can happen when inserting multiple items at the time (`store(entities:)`) or if, for some reason, an aggregate would reference the same object multiple times.

## 🔨 Implementation details

- Remove `applyChildrenChanges`: it was now useless as we remove all children relations before doing any update
- Use `ObservationRegistry` to check if a node was already modified during the transaction. If it's the case: ignore subsequent changes.