### PR TITLE
fix(observer): send first value sync

### DIFF
--- a/Sources/CohesionKit/Combine/EntityObserver+Publisher.swift
+++ b/Sources/CohesionKit/Combine/EntityObserver+Publisher.swift
@@ -4,11 +4,10 @@ import Combine
 extension Observer {
     /// A `Publisher` emitting the observer current value and subscribing to any subsequents new values
     public var asPublisher: AnyPublisher<T, Never> {
-        let subject = CurrentValueSubject<T?, Never>(nil)
+        let subject = CurrentValueSubject<T, Never>(value)
         let subscription = observe(onChange: subject.send)
 
         return subject
-            .compactMap { $0 }
             .handleEvents(receiveCancel: { subscription.unsubscribe() })
             .eraseToAnyPublisher()
     }

--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -14,9 +14,10 @@ public class IdentityMap {
     private lazy var storeVisitor = IdentityMapStoreVisitor(identityMap: self)
 
     /// Create a new IdentityMap instance optionally with a queue and a logger
-    /// - Parameter queue: the queue on which to receive updates. If not defined it default to main
+    /// - Parameter queue: the queue on which to receive updates. If nil identitymap will create its own. DO NOT USE
+    /// main thread as you may end up with data races
     /// - Parameter logger: a logger to follow/debug identity internal state
-    public convenience init(queue: DispatchQueue = .main, logger: Logger? = nil) {
+    public convenience init(queue: DispatchQueue? = nil, logger: Logger? = nil) {
         self.init(registry: ObserverRegistry(queue: queue), logger: logger)
     }
 

--- a/Sources/CohesionKit/Observer/EntityObserver.swift
+++ b/Sources/CohesionKit/Observer/EntityObserver.swift
@@ -13,6 +13,6 @@ public struct EntityObserver<T>: Observer {
     }
 
     public func observe(onChange: @escaping (T) -> Void) -> Subscription {
-        registry.addObserver(node: node, onChange: onChange)
+        registry.addObserver(node: node, initial: true, onChange: onChange)
     }
 }

--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -15,8 +15,8 @@ class ObserverRegistry {
     /// nodes waiting for notifiying their observes about changes
     private var pendingChanges: [Hash: AnyWeak] = [:]
 
-    init(queue: DispatchQueue) {
-        self.queue = queue
+    init(queue: DispatchQueue? = nil) {
+        self.queue = queue ?? DispatchQueue(label: "com.cohesionkit.registry")
     }
 
     /// register an observer to observe changes on an entity node. Everytime `ObserverRegistry` is notified about changes
@@ -33,9 +33,14 @@ class ObserverRegistry {
         }
 
         if initial {
-           // queue.sync {
-                onChange(node.ref.value)
-           // }
+          if queue == DispatchQueue.main && Thread.isMainThread {
+            onChange(node.ref.value)
+          }
+          else {
+            queue.sync {
+              onChange(node.ref.value)
+            }
+          }
         }
 
         // subscription keeps a strong ref to node, avoiding it from being released somehow while suscription is running

--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -21,7 +21,7 @@ class ObserverRegistry {
 
     /// register an observer to observe changes on an entity node. Everytime `ObserverRegistry` is notified about changes
     /// to this node `onChange` will be called.
-    func addObserver<T>(node: EntityNode<T>, onChange: @escaping (T) -> Void) -> Subscription {
+    func addObserver<T>(node: EntityNode<T>, initial: Bool = false, onChange: @escaping (T) -> Void) -> Subscription {
         let observerID = generateID()
 
         observers[node.hashValue, default: [:]][observerID] = {
@@ -30,6 +30,12 @@ class ObserverRegistry {
             }
 
             onChange(newValue.ref.value)
+        }
+
+        if initial {
+           // queue.sync {
+                onChange(node.ref.value)
+           // }
         }
 
         // subscription keeps a strong ref to node, avoiding it from being released somehow while suscription is running

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -191,8 +191,14 @@ extension IdentityMapTests {
         let entity = SingleNodeFixture(id: 1)
         let update = SingleNodeFixture(id: 1, primitive: "Updated by Aggregate")
         let insertion = identityMap.store(entity: entity)
+        var firstDropped = false
 
         let subscription = insertion.observe {
+            guard firstDropped else {
+                firstDropped = true
+                return
+            }
+
             XCTAssertEqual($0, update)
         }
 


### PR DESCRIPTION
## ⚽️ Description

Previous MR broke first value which was always sent asynchronously. While this seems cool it meant delay in displaying in some cases.

## 🔨 Implementation details

When registering, first value can be sent right away