### PR TITLE
tech(observer): Use registry to observe arrays

### DIFF
--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -91,7 +91,7 @@ public class IdentityMap {
 
     /// Store multiple entities at once
     public func store<C: Collection>(entities: C, named: AliasKey<C>? = nil, modifiedAt: Stamp? = nil)
-    -> [EntityObserver<C.Element>] where C.Element: Identifiable {
+    -> EntityObserver<[C.Element]> where C.Element: Identifiable {
         transaction {
             let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
 
@@ -100,13 +100,13 @@ public class IdentityMap {
                 logger?.didRegisterAlias(alias)
             }
 
-            return nodes.map { EntityObserver(node: $0, registry: registry) }
+            return EntityObserver(nodes: nodes, registry: registry)
         }
     }
 
     /// store multiple aggregates at once
     public func store<C: Collection>(entities: C, named: AliasKey<C>? = nil, modifiedAt: Stamp? = nil)
-    -> [EntityObserver<C.Element>] where C.Element: Aggregate {
+    -> EntityObserver<[C.Element]> where C.Element: Aggregate {
         transaction {
             let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
 
@@ -115,7 +115,7 @@ public class IdentityMap {
                 logger?.didRegisterAlias(alias)
             }
 
-            return nodes.map { EntityObserver(node: $0, registry: registry) }
+            return EntityObserver(nodes: nodes, registry: registry)
         }
     }
 

--- a/Sources/CohesionKit/Identity/IdentityStore.swift
+++ b/Sources/CohesionKit/Identity/IdentityStore.swift
@@ -14,8 +14,7 @@ public class IdentityMap {
     private lazy var storeVisitor = IdentityMapStoreVisitor(identityMap: self)
 
     /// Create a new IdentityMap instance optionally with a queue and a logger
-    /// - Parameter queue: the queue on which to receive updates. If nil identitymap will create its own. DO NOT USE
-    /// main thread as you may end up with data races
+    /// - Parameter queue: the queue on which to receive updates. If nil identitymap will create its own.
     /// - Parameter logger: a logger to follow/debug identity internal state
     public convenience init(queue: DispatchQueue? = nil, logger: Logger? = nil) {
         self.init(registry: ObserverRegistry(queue: queue), logger: logger)

--- a/Sources/CohesionKit/Observer/EntityObserver.swift
+++ b/Sources/CohesionKit/Observer/EntityObserver.swift
@@ -2,17 +2,27 @@ import Foundation
 
 /// A type registering observers on a given entity from identity storage
 public struct EntityObserver<T>: Observer {
-    let node: EntityNode<T>
-    let registry: ObserverRegistry
+    public typealias OnChange = (T) -> Void
+
     public let value: T
 
+    let createObserver: (@escaping OnChange) -> Subscription
+
     init(node: EntityNode<T>, registry: ObserverRegistry) {
-        self.registry = registry
-        self.node = node
-        self.value = node.value as! T
+        self.value = node.ref.value
+        self.createObserver = { onChange in
+            registry.addObserver(node: node, initial: true, onChange: onChange)
+        }
     }
 
-    public func observe(onChange: @escaping (T) -> Void) -> Subscription {
-        registry.addObserver(node: node, initial: true, onChange: onChange)
+    init<Element>(nodes: [EntityNode<Element>], registry: ObserverRegistry) where T == [Element] {
+        self.value = nodes.map(\.ref.value)
+        self.createObserver = { onChange in
+            registry.addObserver(nodes: nodes, initial: true, onChange: onChange)
+        }
+    }
+
+    public func observe(onChange: @escaping OnChange) -> Subscription {
+        createObserver(onChange)
     }
 }

--- a/Sources/CohesionKit/Observer/Observer.swift
+++ b/Sources/CohesionKit/Observer/Observer.swift
@@ -1,34 +1,15 @@
 /// A protocol allowing to observe a value returned from the `IdentityMap`
 public protocol Observer {
     associatedtype T
-    
+
     /// The value at the time the observer creation.
     /// If you want **realtime** value use `observe to get notified of changes
     var value: T { get }
-    
+
     /// Add an observer being notified when entity change.
     /// Alternatively you can use `asPublisher` to observe using Combine.
     /// - Parameter onChange: a closure called when value changed
     /// - Returns: a subscription to cancel observation. Observation is automatically cancelled if subscription is deinit.
     /// As long as the subscription is alived the entity should be kept in `IdentityMap`.
     func observe(onChange: @escaping (T) -> Void) -> Subscription
-}
-
-extension Array: Observer where Element: Observer {
-    public var value: [Element.T] { map(\.value) }
-    
-    public func observe(onChange: @escaping ([Element.T]) -> Void) -> Subscription {
-        var value = value
-        
-        let subscriptions = indices.map { index in
-            self[index].observe {
-                value[index] = $0
-                onChange(value)
-            }
-        }
-        
-        return Subscription {
-            subscriptions.forEach { $0.unsubscribe() }
-        }
-    }
 }

--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -16,7 +16,7 @@ class ObserverRegistry {
     private var pendingChanges: [Hash: AnyWeak] = [:]
 
     init(queue: DispatchQueue? = nil) {
-        self.queue = queue ?? DispatchQueue(label: "com.cohesionkit.registry")
+        self.queue = queue ?? DispatchQueue.main
     }
 
     /// register an observer to observe changes on an entity node. Everytime `ObserverRegistry` is notified about changes

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -268,10 +268,16 @@ extension IdentityMapTests {
         let identityMap = IdentityMap(queue: .main)
         let newEntity = SingleNodeFixture(id: 2)
         let expectation = XCTestExpectation()
+        var firstDropped = false
 
         _ = identityMap.store(entity: SingleNodeFixture(id: 1), named: .test, modifiedAt: 0)
 
         let subscription = identityMap.find(named: .test).observe {
+            guard firstDropped else {
+                firstDropped = true
+                return
+            }
+
             expectation.fulfill()
             XCTAssertEqual($0, newEntity)
         }
@@ -289,10 +295,16 @@ extension IdentityMapTests {
         let identityMap = IdentityMap(queue: .main)
         let entities = [SingleNodeFixture(id: 1)]
         let expectation = XCTestExpectation()
+        var firstDropped = false
 
         _ = identityMap.store(entities: [], named: .listOfNodes, modifiedAt: 0)
 
         let subscription = identityMap.find(named: .listOfNodes).observe {
+            guard firstDropped else {
+                firstDropped = true
+                return
+            }
+
             expectation.fulfill()
             XCTAssertEqual($0, entities)
         }


### PR DESCRIPTION
## ⚽️ Description

Use ObserverRegistry to handle array observation. This allows to avoid having multiple update notifications for arrays. This also fix "regression" from previous MR which triggered n notifications for initial value.

## 🔨 Implementation details

- Added addObserver for arrays
- Registry observers are now objects and named `Handler`
- Handler is shared across each array objects
- `postChanges` check a handler is called only once