### PR TITLE
fix(store): Fixed storeAlias not storing relationships

### DIFF
--- a/Sources/CohesionKit/Storage/AliasContainer.swift
+++ b/Sources/CohesionKit/Storage/AliasContainer.swift
@@ -8,32 +8,36 @@ struct AliasContainer<T>: Identifiable, Aggregate {
     var content: T?
 }
 
-extension AliasContainer where T: Aggregate {
-    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<AliasContainer<T>>] {
-     [.init(\.content)]
-    }
-}
-
-extension AliasContainer where T: Identifiable {
-    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<AliasContainer<T>>] {
-     [.init(\.content)]
-    }
-}
-
-extension AliasContainer where T: MutableCollection, T.Element: Aggregate, T.Index: Hashable {
-    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<AliasContainer<T>>] {
-     [.init(\.content)]
-    }
-}
-
-extension AliasContainer where T: MutableCollection, T.Element: Identifiable, T.Index: Hashable {
-    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<AliasContainer<T>>] {
-     [.init(\.content)]
-    }
-}
-
 extension AliasContainer {
-    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<AliasContainer<T>>] {
-     []
+    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<Self>] {
+        if let self = self as? IdentifiableKeyPathsEraser {
+            return self.erasedEntitiesKeyPaths as! [PartialIdentifiableKeyPath<Self>]
+        }
+
+        if let self = self as? CollectionIdentifiableKeyPathsEraser {
+            return self.erasedEntitiesKeyPaths as! [PartialIdentifiableKeyPath<Self>]
+        }
+
+        return []
+    }
+}
+
+private protocol IdentifiableKeyPathsEraser {
+    var erasedEntitiesKeyPaths: [Any] { get }
+}
+
+extension AliasContainer: IdentifiableKeyPathsEraser where T: Identifiable {
+    var erasedEntitiesKeyPaths: [Any] {
+        [PartialIdentifiableKeyPath<Self>(\.content)]
+    }
+}
+
+private protocol CollectionIdentifiableKeyPathsEraser {
+    var erasedEntitiesKeyPaths: [Any] { get }
+}
+
+extension AliasContainer: CollectionIdentifiableKeyPathsEraser where T: MutableCollection, T.Element: Identifiable, T.Index: Hashable {
+    var erasedEntitiesKeyPaths: [Any] {
+        [PartialIdentifiableKeyPath<Self>(\.content)]
     }
 }

--- a/Tests/CohesionKitTests/IdentityMapTests.swift
+++ b/Tests/CohesionKitTests/IdentityMapTests.swift
@@ -141,7 +141,7 @@ class IdentityMapTests: XCTestCase {
         wait(for: [expectation], timeout: 0)
     }
 
-    func test_storeAlias_itEnqueuesAliasInRegistry() {
+    func test_storeAggregate_named_itEnqueuesAliasInRegistry() {
         let root = SingleNodeFixture(id: 1)
         let registry = ObserverRegistryStub()
         let identityMap = IdentityMap(registry: registry)
@@ -216,6 +216,23 @@ extension IdentityMapTests {
         withExtendedLifetime(subscription) {
             _ = identityMap.store(entity: RootFixture(id: 1, primitive: "", singleNode: update, listNodes: []))
         }
+    }
+
+    func test_find_storedByAliasCollection_itReturnsEntity() {
+        let identityMap = IdentityMap()
+
+        _ = identityMap.store(entities: [SingleNodeFixture(id: 1)], named: .listOfNodes)
+
+        XCTAssertNotNil(identityMap.find(SingleNodeFixture.self, id: 1))
+    }
+
+    func test_find_storedByAliasAggregate_itReturnsEntity() {
+        let identityMap = IdentityMap()
+        let aggregate = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), listNodes: [])
+
+        _ = identityMap.store(entity: aggregate, named: .root)
+
+        XCTAssertNotNil(identityMap.find(SingleNodeFixture.self, id: 1))
     }
 
     func test_findNamed_entityStored_noObserver_returnValue() {


### PR DESCRIPTION
## ⚽️ Description

Fixed a bug from previous MR: storeAlias was not creating/storing relationships

## 🔨 Implementation details

- Call `nodeStore` on aliasNode instead of using `updateEntity`
- Change implementation of `AliasContainer.nestedEntitiesKeyPaths`