### PR TITLE
fix(store): Fixed multiple store not working when alias is a collection

### DIFF
--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -77,11 +77,11 @@ public class IdentityMap {
                 update?(&entity)
             }
 
-            let node = nodeStore(entity: entity, modifiedAt: modifiedAt)
-
             if let key = named {
                 storeAlias(content: entity, key: key, modifiedAt: modifiedAt)
             }
+
+            let node = nodeStore(entity: entity, modifiedAt: modifiedAt)
 
             return EntityObserver(node: node, registry: registry)
         }
@@ -91,11 +91,11 @@ public class IdentityMap {
     public func store<C: Collection>(entities: C, named: AliasKey<C>? = nil, modifiedAt: Stamp? = nil)
     -> EntityObserver<[C.Element]> where C.Element: Identifiable {
         transaction {
-            let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
-
             if let key = named {
                 storeAlias(content: entities, key: key, modifiedAt: modifiedAt)
             }
+
+            let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
 
             return EntityObserver(nodes: nodes, registry: registry)
         }
@@ -105,11 +105,12 @@ public class IdentityMap {
     public func store<C: Collection>(entities: C, named: AliasKey<C>? = nil, modifiedAt: Stamp? = nil)
     -> EntityObserver<[C.Element]> where C.Element: Aggregate {
         transaction {
-            let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
-
             if let key = named {
                 storeAlias(content: entities, key: key, modifiedAt: modifiedAt)
             }
+
+            let nodes = entities.map { nodeStore(entity: $0, modifiedAt: modifiedAt) }
+
 
             return EntityObserver(nodes: nodes, registry: registry)
         }
@@ -212,7 +213,6 @@ public class IdentityMap {
             return returnValue
         }
     }
-
 }
 
 // MARK: Update


### PR DESCRIPTION
## ⚽️ Description

Fix a regression where alias was failing to be restored when it is a collection. This is because alias was already marked as updated, which it indeed was but not with the expected value.

## 🔨 Implementation details

For now the fix is to store alias first. In future would be good to _only_ store alias when there's one. This would avoid a useless call.