### PR TITLE
fix(node): Don't apply changes while inserting aggregate

### DIFF
--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -183,9 +183,11 @@ public class EntityStore {
         // clear all children to avoid a removed child to be kept as child
         node.removeAllChildren()
 
+        node.applyChildrenChanges = false
         for keyPathContainer in entity.nestedEntitiesKeyPaths {
             keyPathContainer.accept(node, entity, modifiedAt, storeVisitor)
         }
+        node.applyChildrenChanges = true
 
         do {
             try node.updateEntity(entity, modifiedAt: modifiedAt)

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -19,6 +19,7 @@ class EntityNode<T>: AnyEntityNode {
 
     var value: Any { ref.value }
 
+    var applyChildrenChanges = true
     /// An observable entity reference
     let ref: Observable<T>
 
@@ -84,6 +85,10 @@ class EntityNode<T>: AnyEntityNode {
         }
 
         let subscription = childNode.ref.addObserver { [unowned self] newValue in
+            guard self.applyChildrenChanges else {
+                return
+            }
+
             update(&self.ref.value, newValue)
             self.onChange?(self)
         }


### PR DESCRIPTION
## ⚽️ Description

Fix a crash where a node might try to update its children while _being_ inserted.

This could happen if the same element is inserted multiple times in a single transaction (for instance, with an array).

Despite facing the bug on my project (while using aliases) I was not able to make a non regression test.

## 🔨 Implementation details

Reintroduce `applyChildrenChanges` to skip any change while inserting/updating the aggregate