### PR TITLE
fix(alias): Send nil when alias is removed

### DIFF
--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -349,25 +349,54 @@ extension EntityStore {
 extension EntityStore {
     /// Removes an alias from the storage
     public func removeAlias<T>(named: AliasKey<T>) {
-        refAliases[named] = nil
-        logger?.didUnregisterAlias(named)
+        transaction {
+            if let alias = refAliases[named] {
+                do {
+                    try alias.updateEntity(AliasContainer(key: named, content: nil), modifiedAt: nil)
+                    logger?.didUnregisterAlias(named)
+                }
+                catch {
+
+                }
+            }
+        }
     }
 
     /// Removes an alias from the storage
     public func removeAlias<C: Collection>(named: AliasKey<C>) {
-        refAliases[named] = nil
-        logger?.didUnregisterAlias(named)
+        transaction {
+            if let alias = refAliases[named] {
+                do {
+                    try alias.updateEntity(AliasContainer(key: named, content: nil), modifiedAt: nil)
+                    logger?.didUnregisterAlias(named)
+                }
+                catch {
+
+                }
+            }
+        }
+
     }
 
     /// Removes all alias from identity map
     public func removeAllAlias() {
-        refAliases.removeAll()
+        transaction {
+            removeAliases()
+        }
     }
 
     /// Removes all alias AND all objects stored weakly. You should not need this method and rather use `removeAlias`.
     /// But this can be useful if you fear retain cycles
     public func removeAll() {
-        refAliases.removeAll()
-        storage.removeAll()
+        transaction {
+            removeAliases()
+            storage.removeAll()
+        }
+    }
+
+    private func removeAliases() {
+        for (_, node) in refAliases {
+                node.nullify()
+        }
     }
 }

--- a/Sources/CohesionKit/Storage/AliasContainer.swift
+++ b/Sources/CohesionKit/Storage/AliasContainer.swift
@@ -69,3 +69,17 @@ extension AliasContainer: CollectionIdentifiableKeyPathsEraser where T: MutableC
         [PartialIdentifiableKeyPath<Self>(\.content)]
     }
 }
+
+extension AliasContainer: Equatable where T: Equatable {
+
+}
+
+protocol Nullable {
+  func nullified() -> Self
+}
+
+extension AliasContainer: Nullable {
+  func nullified() -> AliasContainer<T> {
+    AliasContainer(key: key, content: nil)
+  }
+}

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -1,5 +1,5 @@
 /// Keep a strong reference on each aliased node
-typealias AliasStorage = [String: Any]
+typealias AliasStorage = [String: AnyEntityNode]
 
 extension AliasStorage {
     subscript<T>(_ aliasKey: AliasKey<T>) -> EntityNode<AliasContainer<T>>? {

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -4,6 +4,8 @@ import Combine
 /// Typed erased protocol
 protocol AnyEntityNode: AnyObject {
     var value: Any { get }
+
+  func nullify()
 }
 
 /// A graph node representing a entity of type `T` and its children. Anytime one of its children is updated the node
@@ -51,6 +53,12 @@ class EntityNode<T>: AnyEntityNode {
         modifiedAt = newModifiedAt ?? modifiedAt
         ref.value = newEntity
         onChange?(self)
+    }
+
+    func nullify() {
+        if let value = ref.value as? Nullable {
+            try? updateEntity(value.nullified() as! T, modifiedAt: nil)
+        }
     }
 
     func removeAllChildren() {

--- a/Tests/CohesionKitTests/EntityStoreTests.swift
+++ b/Tests/CohesionKitTests/EntityStoreTests.swift
@@ -424,6 +424,37 @@ extension EntityStoreTests {
     }
 }
 
+// MARK: Remove
+extension EntityStoreTests {
+    func test_removeAlias_itEnqueuesNilInRegistry() {
+        let registry = ObserverRegistryStub()
+        let store = EntityStore(registry: registry)
+
+        _ = store.store(entity: SingleNodeFixture(id: 1), named: .test)
+
+        registry.clearPendingChangesStub()
+
+        store.removeAlias(named: .test)
+
+        XCTAssertTrue(registry.hasPendingChange(for: AliasContainer(key: .test, content: nil)))
+    }
+
+    func test_removeAllAlias_itEnqueuesNilForEachAlias() {
+        let registry = ObserverRegistryStub()
+        let store = EntityStore(registry: registry)
+
+        _ = store.store(entity: SingleNodeFixture(id: 1), named: .test)
+        _ = store.store(entities: [SingleNodeFixture(id: 2)], named: .listOfNodes)
+
+        registry.clearPendingChangesStub()
+
+        store.removeAllAlias()
+
+        XCTAssertTrue(registry.hasPendingChange(for: AliasContainer(key: .test, content: nil)))
+        XCTAssertTrue(registry.hasPendingChange(for: AliasContainer(key: .listOfNodes, content: nil)))
+    }
+}
+
 private extension AliasKey where T == SingleNodeFixture {
     static let test = AliasKey(named: "test")
 }


### PR DESCRIPTION
## ⚽️ Description

When calling one of the method removing an alias, the observers were notified of such thing. Now send nil when alias is removed.

## 🔨 Implementation details

The implementation is a quick fix. Hopefully I will be able to improve it:

- Add a method to `AnyEntityNode` to be able to nullify the entity. Needed in order to iterate over all aliases and set them to nil.