### PR TITLE
tech(registry): Add key parameter

### DIFF
--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -1,15 +1,25 @@
 import Foundation
 
+/// a unique hash identifying an object
+typealias ObjectKey = Int
+
+extension ObjectKey {
+    init<T>(of type: T.Type, id: Any) {
+        let key = "\(type)-\(id)"
+
+        self.init(key.hashValue)
+    }
+}
+
 /// Registers observers associated to an ``EntityNode``.
 /// The registry will handle notifying observers when a node is marked as changed
 class ObserverRegistry {
-    private typealias Hash = Int
 
     let queue: DispatchQueue
     /// registered observer handlers
-    private var handlers: [Hash: Set<Handler>] = [:]
+    private var handlers: [ObjectKey: Set<Handler>] = [:]
     /// nodes waiting for notifiying their observes about changes
-    private var pendingChanges: [Hash: AnyWeak] = [:]
+    private var pendingChanges: [ObjectKey: AnyWeak] = [:]
 
     init(queue: DispatchQueue? = nil) {
         self.queue = queue ?? DispatchQueue.main

--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -29,9 +29,13 @@ class ObserverRegistry {
         self.queue = queue ?? DispatchQueue.main
     }
 
+    func addObserver<T>(node: EntityNode<T>, initial: Bool = false, onChange: @escaping (T) -> Void) -> Subscription {
+        addObserver(node: node, key: ObjectKey(node), initial: initial, onChange: onChange)
+    }
+
     /// register an observer to observe changes on an entity node. Everytime `ObserverRegistry` is notified about changes
     /// to this node `onChange` will be called.
-    func addObserver<T>(node: EntityNode<T>, initial: Bool = false, onChange: @escaping (T) -> Void) -> Subscription {
+    func addObserver<T>(node: EntityNode<T>, key: ObjectKey, initial: Bool = false, onChange: @escaping (T) -> Void) -> Subscription {
         let handler = Handler { onChange($0.ref.value) }
 
         if initial {
@@ -45,7 +49,7 @@ class ObserverRegistry {
           }
         }
 
-        return subscribeHandler(handler, for: node, key: ObjectKey(node))
+        return subscribeHandler(handler, for: node, key: key)
     }
 
     /// Add an observer handler to multiple nodes.

--- a/Sources/CohesionKit/Observer/ObserverRegistry.swift
+++ b/Sources/CohesionKit/Observer/ObserverRegistry.swift
@@ -9,6 +9,10 @@ extension ObjectKey {
 
         self.init(key.hashValue)
     }
+
+    init<T>(_ node: EntityNode<T>) {
+        self.init(of: T.self, id: node.hashValue)
+    }
 }
 
 /// Registers observers associated to an ``EntityNode``.
@@ -41,7 +45,7 @@ class ObserverRegistry {
           }
         }
 
-        return subscribeHandler(handler, for: node, key: node.hashValue)
+        return subscribeHandler(handler, for: node, key: ObjectKey(node))
     }
 
     /// Add an observer handler to multiple nodes.
@@ -63,7 +67,7 @@ class ObserverRegistry {
           }
         }
 
-        let subscriptions = nodes.map { node in subscribeHandler(handler, for: node, key: node.hashValue) }
+        let subscriptions = nodes.map { node in subscribeHandler(handler, for: node, key: ObjectKey(node)) }
 
         return Subscription {
             subscriptions.forEach { $0.unsubscribe() }
@@ -72,7 +76,7 @@ class ObserverRegistry {
 
     /// Mark a node as changed. Observers won't be notified of the change until ``postChanges`` is called
     func enqueueChange<T>(for node: EntityNode<T>) {
-        enqueueChange(for: node, key: node.hashValue)
+        enqueueChange(for: node, key: ObjectKey(node))
     }
 
     func enqueueChange<T>(for node: EntityNode<T>, key: ObjectKey) {
@@ -80,7 +84,7 @@ class ObserverRegistry {
     }
 
     func hasPendingChange<T>(for node: EntityNode<T>) -> Bool {
-        hasPendingChange(for: node.hashValue)
+        hasPendingChange(for: ObjectKey(node))
     }
 
     func hasPendingChange(for key: ObjectKey) -> Bool {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,7 @@ platform :ios do
     scheme: "Example",
     configuration: "Debug",
     build: true,
-    destination: "platform=iOS Simulator,name=iPhone SE (2nd generation)"
+    destination: "platform=iOS Simulator,name=iPhone SE (3rd generation)"
   )
   end
 end


### PR DESCRIPTION
## ⚽️ Description

Registry now ask (most of the time) the node key, which allows to provide a custom value. This is a 1st step on same new implementation I have in mind which should drastically simplify `EntityStore`.

## 🔨 Implementation details

Default implementation compute the key as before for backward compatibility. 