### PR TITLE
tech(unit tests): Don't use EntityStore internal properties

### DIFF
--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -12,8 +12,8 @@ public class EntityStore {
     private let logger: Logger?
     private let registry: ObserverRegistry
 
-    private(set) var storage: EntitiesStorage = EntitiesStorage()
-    private(set) var refAliases: AliasStorage = [:]
+    private var storage: EntitiesStorage = EntitiesStorage()
+    private var refAliases: AliasStorage = [:]
     private lazy var storeVisitor = EntityStoreStoreVisitor(entityStore: self)
 
     /// Create a new EntityStore instance optionally with a queue and a logger

--- a/Tests/CohesionKitTests/EntityStoreTests.swift
+++ b/Tests/CohesionKitTests/EntityStoreTests.swift
@@ -14,18 +14,18 @@ class EntityStoreTests: XCTestCase {
         let entityStore = EntityStore()
 
         withExtendedLifetime(entityStore.store(entity: entity)) { _ in
-            XCTAssertNotNil(entityStore.storage[SingleNodeFixture.self, id: 1])
-            XCTAssertNotNil(entityStore.storage[OptionalNodeFixture.self, id: 1])
-            XCTAssertNotNil(entityStore.storage[ListNodeFixture.self, id: 1])
+            XCTAssertNotNil(entityStore.find(SingleNodeFixture.self, id: 1))
+            XCTAssertNotNil(entityStore.find(OptionalNodeFixture.self, id: 1))
+            XCTAssertNotNil(entityStore.find(ListNodeFixture.self, id: 1))
         }
     }
 
-    func test_storeAggregate_nestedEntityReplacedByNil_entityIsUpdated_aggregateEntityRemainsNil() {
+    func test_storeAggregate_nestedEntitySetToNil_entityIsUpdated_aggregateNestedEntityRemainsNil() throws {
         let entityStore = EntityStore()
         let nestedOptional = OptionalNodeFixture(id: 1)
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: nestedOptional, listNodes: [])
 
-        withExtendedLifetime(entityStore.store(entity: root)) {
+        try withExtendedLifetime(entityStore.store(entity: root)) {
             root.optional = nil
 
             _ = entityStore.store(entity: root)
@@ -33,52 +33,56 @@ class EntityStoreTests: XCTestCase {
 
             XCTAssertNotNil(entityStore.find(RootFixture.self, id: 1))
             XCTAssertNil(entityStore.find(RootFixture.self, id: 1)!.value.optional)
+            let root = try XCTUnwrap(entityStore.find(RootFixture.self, id: 1))
+            XCTAssertNil(root.value.optional)
         }
     }
 
     /// check that removed relations do not trigger an update
-    func test_storeAggregate_removeEntityFromNestedArray_removedEntityChange_aggregateArrayNotChanged() {
+    func test_storeAggregate_removeEntityFromNestedArray_removedEntityChange_aggregateArrayNotChanged() throws {
         let entityStore = EntityStore()
         var entityToRemove = ListNodeFixture(id: 2)
         let nestedArray: [ListNodeFixture] = [entityToRemove, ListNodeFixture(id: 1)]
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: OptionalNodeFixture(id: 1), listNodes: nestedArray)
 
-        withExtendedLifetime(entityStore.store(entity: root)) {
+        try withExtendedLifetime(entityStore.store(entity: root)) {
             root.listNodes = Array(nestedArray[1...])
             entityToRemove.key = "changed"
 
             _ = entityStore.store(entity: root)
             _ = entityStore.store(entity: entityToRemove)
 
-            let storedRoot = entityStore.find(RootFixture.self, id: 1)!.value
+            let root = try XCTUnwrap(entityStore.find(RootFixture.self, id: 1))
 
-            XCTAssertFalse(storedRoot.listNodes.contains(entityToRemove))
-            XCTAssertFalse(storedRoot.listNodes.map(\.id).contains(entityToRemove.id))
+            XCTAssertFalse(root.value.listNodes.contains(entityToRemove))
+            XCTAssertFalse(root.value.listNodes.map(\.id).contains(entityToRemove.id))
         }
     }
 
-    func test_storeAggregate_nestedWrapperChanged_aggregateIsUpdated() {
+    func test_storeAggregate_nestedWrapperChanged_aggregateIsUpdated() throws {
         let entityStore = EntityStore()
         let root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: OptionalNodeFixture(id: 1), listNodes: [], enumWrapper: .single(SingleNodeFixture(id: 2)))
         let updatedValue = SingleNodeFixture(id: 2, primitive: "updated")
 
-        withExtendedLifetime(entityStore.store(entity: root)) {
+        try withExtendedLifetime(entityStore.store(entity: root)) {
             _ = entityStore.store(entity: updatedValue)
-            XCTAssertEqual(entityStore.find(RootFixture.self, id: 1)!.value.enumWrapper, .single(updatedValue))
+            let root = try XCTUnwrap(entityStore.find(RootFixture.self, id: 1))
+            XCTAssertEqual(root.value.enumWrapper, .single(updatedValue))
         }
     }
 
-    func test_storeAggregate_nestedOptionalWrapperNullified_aggregateIsNullified() {
+    func test_storeAggregate_nestedOptionalWrapperNullified_aggregateIsNullified() throws {
         let entityStore = EntityStore()
         var root = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), optional: OptionalNodeFixture(id: 1), listNodes: [], enumWrapper: .single(SingleNodeFixture(id: 2)))
 
-        withExtendedLifetime(entityStore.store(entity: root)) {
+        try withExtendedLifetime(entityStore.store(entity: root)) {
             root.enumWrapper = nil
 
             _ = entityStore.store(entity: root)
             _ = entityStore.store(entity: SingleNodeFixture(id: 2, primitive: "deleted"))
 
-            XCTAssertNil(entityStore.find(RootFixture.self, id: 1)!.value.enumWrapper)
+            let root = try XCTUnwrap(entityStore.find(RootFixture.self, id: 1))
+            XCTAssertNil(root.value.enumWrapper)
         }
     }
 


### PR DESCRIPTION

<!--
  Add a label matching closely the PR topic:
  - "bug" for bugfixes
  - "feature" for feature topic
  - "doc" for tech PR about documentation
  - "enhancement" for anything else or when one of the label mentioned above is missing
-->

## ⚽️ Description

Small cleaning on unit tests

## 🔨 Implementation details

- Use `find` instead of internal properties
- Use `XCTUnwrap` to unwrap optional properties