### PR TITLE
tech(entity): Introduce metadata system

### DIFF
--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -180,6 +180,14 @@ public class EntityStore {
             return node
         }
 
+        for (childRef, _) in node.metadata.childrenRefs {
+            guard let childNode = storage[childRef]?.unwrap() as? AnyEntityNode else {
+                continue
+            }
+
+            childNode.removeParent(node)
+        }
+
         // clear all children to avoid a removed child to be kept as child
         node.removeAllChildren()
 
@@ -195,6 +203,14 @@ public class EntityStore {
         }
         catch {
             logger?.didFailedToStore(T.self, id: entity.id, error: error)
+        }
+
+        for parentRef in node.metadata.parentsRefs {
+            guard let parentNode = storage[parentRef]?.unwrap() as? AnyEntityNode else {
+                continue
+            }
+
+            parentNode.updateEntityRelationship(node)
         }
 
         return node

--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -162,6 +162,7 @@ public class EntityStore {
 
         do {
             try node.updateEntity(entity, modifiedAt: modifiedAt)
+            registry.enqueueChange(for: node)
             logger?.didStore(T.self, id: entity.id)
         }
         catch {
@@ -199,6 +200,7 @@ public class EntityStore {
 
         do {
             try node.updateEntity(entity, modifiedAt: modifiedAt)
+            registry.enqueueChange(for: node)
             logger?.didStore(T.self, id: entity.id)
         }
         catch {
@@ -211,6 +213,7 @@ public class EntityStore {
             }
 
             parentNode.updateEntityRelationship(node)
+            parentNode.enqueue(in: registry)
         }
 
         return node
@@ -402,7 +405,9 @@ extension EntityStore {
 
     private func removeAliases() {
         for (_, node) in refAliases {
-                node.nullify()
+            if node.nullify() {
+                node.enqueue(in: registry)
+            }
         }
     }
 }

--- a/Sources/CohesionKit/EntityStore.swift
+++ b/Sources/CohesionKit/EntityStore.swift
@@ -169,6 +169,15 @@ public class EntityStore {
             logger?.didFailedToStore(T.self, id: entity.id, error: error)
         }
 
+        for parentRef in node.metadata.parentsRefs {
+            guard let parentNode = storage[parentRef]?.unwrap() as? AnyEntityNode else {
+                continue
+            }
+
+            parentNode.updateEntityRelationship(node)
+            parentNode.enqueue(in: registry)
+        }
+
         return node
     }
 

--- a/Sources/CohesionKit/Storage/AliasStorage.swift
+++ b/Sources/CohesionKit/Storage/AliasStorage.swift
@@ -1,5 +1,5 @@
 /// Keep a strong reference on each aliased node
-typealias AliasStorage = [String: AnyEntityNode]
+typealias AliasStorage = [String: any AnyEntityNode]
 
 extension AliasStorage {
     subscript<T>(_ aliasKey: AliasKey<T>) -> EntityNode<AliasContainer<T>>? {
@@ -9,7 +9,8 @@ extension AliasStorage {
 
     subscript<T>(safe key: AliasKey<T>, onChange onChange: ((EntityNode<AliasContainer<T>>) -> Void)? = nil) -> EntityNode<AliasContainer<T>> {
         mutating get {
-            self[key: key, default: EntityNode(AliasContainer(key: key), modifiedAt: nil, onChange: onChange)]
+            let storeKey = buildKey(for: T.self, key: key)
+            return self[key: key, default: EntityNode(AliasContainer(key: key), key: storeKey, modifiedAt: nil, onChange: onChange)]
         }
     }
 

--- a/Sources/CohesionKit/Storage/EntitiesStorage.swift
+++ b/Sources/CohesionKit/Storage/EntitiesStorage.swift
@@ -19,6 +19,11 @@ struct EntitiesStorage {
         set { indexes[key(for: T.self, id: id)] = Weak(value: newValue) }
     }
 
+    subscript(_ key: String) -> AnyWeak? {
+        get { indexes[key] }
+        set { indexes[key] = newValue }
+    }
+
     private func key<T>(for type: T.Type, id: Any) -> String {
         "\(type)-\(id)"
     }

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -1,11 +1,31 @@
 import Foundation
 import Combine
 
+struct EntityMetadata {
+    /// children this entity is referencing/using
+    /// key: the children keypath in the parent, value: the key in EntitieStorage
+    // TODO: change value to a ObjectKey
+    var childrenRefs: [AnyKeyPath: String] = [:]
+
+    /// parents referencing this entity. This means this entity should be listed inside its parents `EntityMetadata.childrenRefs` attribute
+    var parentsRefs: Set<ObjectKey> = []
+    /// alias referencing this entity
+    var aliasesRefs: Set<String> = []
+
+    /// number of observers
+    var observersCount: Int = 0
+
+    var isActivelyUsed: Bool {
+        observersCount > 0 || !parentsRefs.isEmpty || !aliasesRefs.isEmpty
+    }
+}
+
 /// Typed erased protocol
 protocol AnyEntityNode: AnyObject {
     var value: Any { get }
+    var metadata: EntityMetadata { get }
 
-  func nullify()
+    func nullify()
 }
 
 /// A graph node representing a entity of type `T` and its children. Anytime one of its children is updated the node

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -41,9 +41,13 @@ class EntityNode<T>: AnyEntityNode {
 
     var value: Any { ref.value }
 
+    var metadata = EntityMetadata()
+
     var applyChildrenChanges = true
     /// An observable entity reference
     let ref: Observable<T>
+
+    let storageKey: String
 
     private let onChange: ((EntityNode<T>) -> Void)?
     /// last time the ref.value was changed. Any subsequent change must have a higher value to be applied
@@ -52,14 +56,20 @@ class EntityNode<T>: AnyEntityNode {
     /// entity children
     private(set) var children: [PartialKeyPath<T>: SubscribedChild] = [:]
 
-    init(ref: Observable<T>, modifiedAt: Stamp?, onChange: ((EntityNode<T>) -> Void)? = nil) {
+    init(ref: Observable<T>, key: String, modifiedAt: Stamp?, onChange: ((EntityNode<T>) -> Void)? = nil) {
         self.ref = ref
         self.modifiedAt = modifiedAt
         self.onChange = onChange
+        self.storageKey = key
     }
 
-    convenience init(_ entity: T, modifiedAt: Stamp?, onChange: ((EntityNode<T>) -> Void)? = nil) {
-        self.init(ref: Observable(value: entity), modifiedAt: modifiedAt, onChange: onChange)
+    convenience init(_ entity: T, key: String, modifiedAt: Stamp?, onChange: ((EntityNode<T>) -> Void)? = nil) {
+        self.init(ref: Observable(value: entity), key: key, modifiedAt: modifiedAt, onChange: onChange)
+    }
+
+    convenience init(_ entity: T, modifiedAt: Stamp?, onChange: ((EntityNode<T>) -> Void)? = nil) where T: Identifiable {
+        let key = "\(T.self)-\(entity.id)"
+        self.init(entity, key: key, modifiedAt: modifiedAt, onChange: onChange)
     }
 
     /// change the entity to a new value. If modifiedAt is nil or > to previous date update the value will be changed

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -31,7 +31,7 @@ protocol AnyEntityNode: AnyObject {
 
     func nullify() -> Bool
     func removeParent(_ node: any AnyEntityNode)
-    func updateEntityRelationship(_ node: some AnyEntityNode)
+    func updateEntityRelationship(_ child: some AnyEntityNode)
     func enqueue(in: ObserverRegistry)
 }
 
@@ -118,18 +118,22 @@ class EntityNode<T>: AnyEntityNode {
         metadata.parentsRefs.remove(node.storageKey)
     }
 
-    func updateEntityRelationship<U: AnyEntityNode>(_ node: U) {
-        guard let keyPath = metadata.childrenRefs[node.storageKey] else {
+    func updateEntityRelationship<U: AnyEntityNode>(_ child: U) {
+        guard applyChildrenChanges else {
+            return
+        }
+
+        guard let keyPath = metadata.childrenRefs[child.storageKey] else {
             return
         }
 
         if let writableKeyPath = keyPath as? WritableKeyPath<T, U.Value> {
-            ref.value[keyPath: writableKeyPath] = node.ref.value
+            ref.value[keyPath: writableKeyPath] = child.ref.value
             return
         }
 
         if let optionalWritableKeyPath = keyPath as? WritableKeyPath<T, U.Value?> {
-            ref.value[keyPath: optionalWritableKeyPath] = node.ref.value
+            ref.value[keyPath: optionalWritableKeyPath] = child.ref.value
             return
         }
 

--- a/Sources/CohesionKit/Storage/EntityNode.swift
+++ b/Sources/CohesionKit/Storage/EntityNode.swift
@@ -130,9 +130,6 @@ class EntityNode<T>: AnyEntityNode {
 
     /// observe one of the node child
     func observeChild<C>(_ childNode: EntityNode<C>, for keyPath: WritableKeyPath<T, C>) {
-        metadata.childrenRefs[childNode.storageKey] = keyPath
-        childNode.metadata.parentsRefs.insert(storageKey)
-
         observeChild(childNode, identity: keyPath) { root, newValue in
             root[keyPath: keyPath] = newValue
         }
@@ -154,6 +151,9 @@ class EntityNode<T>: AnyEntityNode {
         identity keyPath: KeyPath<T, C>,
         update: @escaping (inout T, Element) -> Void
     ) {
+        metadata.childrenRefs[childNode.storageKey] = keyPath
+        childNode.metadata.parentsRefs.insert(storageKey)
+
         if let subscribedChild = children[keyPath]?.node as? EntityNode<Element>, subscribedChild == childNode {
             return
         }

--- a/Tests/CohesionKitTests/EntityStoreTests.swift
+++ b/Tests/CohesionKitTests/EntityStoreTests.swift
@@ -411,7 +411,7 @@ extension EntityStoreTests {
         XCTAssertTrue(registry.hasPendingChange(for: AliasContainer<RootFixture>.self))
     }
 
-    func test_update_entityIsIndirectlyUsedByAlias_itEnqueuesAliasInRegistry() {
+    func test_update_entityIsInsideAggregagte_aggreateIsAliased_itEnqueuesAliasInRegistry() {
         let aggregate = RootFixture(id: 1, primitive: "", singleNode: SingleNodeFixture(id: 1), listNodes: [])
         let registry = ObserverRegistryStub()
         let entityStore = EntityStore(registry: registry)

--- a/Tests/CohesionKitTests/RootFixture.swift
+++ b/Tests/CohesionKitTests/RootFixture.swift
@@ -1,6 +1,24 @@
 import Foundation
 import CohesionKit
 
+struct AFixture: Aggregate {
+    var id: BFixture.ID { b.id }
+    var b: BFixture
+
+    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<Self>] {
+        [.init(\.b)]
+    }
+}
+
+struct BFixture: Aggregate {
+    var id: SingleNodeFixture.ID { c.id }
+    var c: SingleNodeFixture
+
+    var nestedEntitiesKeyPaths: [PartialIdentifiableKeyPath<Self>] {
+        [.init(\.c)]
+    }
+}
+
 struct RootFixture: Aggregate, Equatable {
     let id: Int
     let primitive: String

--- a/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
+++ b/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
@@ -68,35 +68,33 @@ class EntityNodeTests: XCTestCase {
         }
     }
 
-    func test_observeChild_childChange_entityIsUpdated() throws {
+    func test_observeChild_nodeIsAddedAsParentMetadata() {
         let childNode = EntityNode(startEntity.singleNode, modifiedAt: nil)
-        let newChild = SingleNodeFixture(id: 1, primitive: "updated")
 
         node.observeChild(childNode, for: \.singleNode)
 
-        try childNode.updateEntity(newChild, modifiedAt: nil)
-
-        XCTAssertEqual((node.value as? RootFixture)?.singleNode, newChild)
+        XCTAssertTrue(childNode.metadata.parentsRefs.contains(node.storageKey))
     }
 
-    func test_observeChild_childChange_entityObserversAreCalled() throws {
+    func test_observeChild_childrenMetadataIsUpdated() {
+        let childNode = EntityNode(startEntity.singleNode, modifiedAt: nil)
+
+        node.observeChild(childNode, for: \.singleNode)
+
+        XCTAssertTrue(node.metadata.childrenRefs.keys.contains(childNode.storageKey))
+    }
+
+    func test_updateEntityRelationship_childIsUpdated() throws {
         let childNode = EntityNode(startEntity.singleNode, modifiedAt: startTimestamp)
         let newChild = SingleNodeFixture(id: 1, primitive: "updated")
-        let entityRef = Observable(value: startEntity)
-        var observerCalled = false
 
-        let subscription = entityRef.addObserver { _ in
-            observerCalled = true
-        }
-
-        node = EntityNode(ref: entityRef, key: "RootFixture-1", modifiedAt: startTimestamp)
         node.observeChild(childNode, for: \.singleNode)
 
         try childNode.updateEntity(newChild, modifiedAt: nil)
 
-        subscription.unsubscribe()
+        node.updateEntityRelationship(childNode)
 
-        XCTAssertTrue(observerCalled)
+        XCTAssertEqual(node.ref.value.singleNode, newChild)
     }
 
     func test_observeChild_childIsCollection_eachChildIsAdded() {
@@ -104,11 +102,11 @@ class EntityNodeTests: XCTestCase {
         let child2 = EntityNode(ListNodeFixture(id: 2), modifiedAt: startTimestamp)
         let node = EntityNode(startEntity, modifiedAt: startTimestamp)
 
-        XCTAssertEqual(node.children.count, 0)
+        XCTAssertEqual(node.metadata.childrenRefs.count, 0)
 
         node.observeChild(child1, for: \.listNodes[0])
         node.observeChild(child2, for: \.listNodes[1])
 
-        XCTAssertEqual(node.children.count, 2)
+        XCTAssertEqual(node.metadata.childrenRefs.count, 2)
     }
 }

--- a/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
+++ b/Tests/CohesionKitTests/Storage/EntityNodeTests.swift
@@ -89,7 +89,7 @@ class EntityNodeTests: XCTestCase {
             observerCalled = true
         }
 
-        node = EntityNode(ref: entityRef, modifiedAt: startTimestamp)
+        node = EntityNode(ref: entityRef, key: "RootFixture-1", modifiedAt: startTimestamp)
         node.observeChild(childNode, for: \.singleNode)
 
         try childNode.updateEntity(newChild, modifiedAt: nil)

--- a/Tests/CohesionKitTests/Visitor/EntityStoreVisitorTests.swift
+++ b/Tests/CohesionKitTests/Visitor/EntityStoreVisitorTests.swift
@@ -59,8 +59,8 @@ class EntityStoreStoreVisitorTests: XCTestCase {
 }
 
 private class EntityNodeStub<T>: EntityNode<T> {
-    var observeChildKeyPathCalled: (AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
-    var observeChildKeyPathOptionalCalled: (AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
+    var observeChildKeyPathCalled: (any AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
+    var observeChildKeyPathOptionalCalled: (any AnyEntityNode, PartialKeyPath<T>) -> Void = { _, _ in }
 
     override func observeChild<C>(_ childNode: EntityNode<C>, for keyPath: WritableKeyPath<T, C>) {
         observeChildKeyPathCalled(childNode, keyPath)


### PR DESCRIPTION
## ⚽️ Description

Introduce a new type, EntityMetadata, to track info about entities. End goal is to internally stop relying on observers, have better debug info about relationships, and have simpler/easier to understand implementation.

## 🔨 Implementation details

- Everytime we insert an object, we'll update its metadata to reflect its children
- Everytime we insert an object, we update its parent to reflect the new value